### PR TITLE
chore: upgrade Go to 1.24, bump version/license; docs: expand README

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 ###### Dockerfile
-FROM golang:1.20-bullseye
+FROM golang:1.24-bullseye
 
 ###### Env 
 ARG USER=builder

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,4 @@
 {
-    "name": "golang-development-kit",
     "build": {
         "dockerfile": "Dockerfile",
         "args": {

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,12 +12,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
-        go-version: '^1.20.0'
+        go-version: '^1.24.0'
 
     - name: Build
       run: make build

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,16 @@
 {
     "editor.renderWhitespace": "boundary",
     "editor.accessibilitySupport": "off",
-    "diffEditor.ignoreTrimWhitespace": false
+    "diffEditor.ignoreTrimWhitespace": false,
+    "github.copilot.chat.commitMessageGeneration.instructions": [
+        {
+            "text": "Please write in English without exception."
+        },
+        {
+            "text": "Start the commit message by following the Conventional Commits format."
+        },
+        {
+            "text": "Then, describe the detailed changes for each file."
+        }          
+    ],
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 pirakansa
+Copyright (c) 2025 pirakansa
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LINUX_ARM   = linux-arm
 LINUX_ARM64 = linux-arm64
 WIN_AMD64   = win-amd64
 SRCDIR      = ./cmd/$(PROJECT_NAME)
-VERSION     = 0.2.0
+VERSION     = 0.2.1
 GO_LDFLAGS  = -ldflags="-s -w -X main.Version=$(VERSION)" -trimpath
 
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
 # private-package-manager
+
+`private-package-manager` is a package management tool built with Go. This tool allows you to download files from specified repositories and save them locally.
+
+## Features
+- Parse YAML files to retrieve repository information.
+- Download files via HTTP.
+- Use `spider` mode to preview download URLs and paths.
+
+## Usage
+
+### Command Examples
+```sh
+$ ppkgmgr <path_to_yaml>  # Execute with a specified YAML file
+$ ppkgmgr --spider <path_to_yaml>  # Preview download URLs and paths
+$ ppkgmgr -v  # Display version information
+```
+
+## YAML Files
+
+The tool relies on YAML files to define the repositories and files to be downloaded. The structure of the YAML file is as follows:
+
+```yaml
+version: 2
+
+repositories:
+  -
+    _comment: <description of the repository>
+    url: <base URL of the repository>
+    files:
+      -
+        file_name: <name of the file to download>
+        out_dir: <output directory for the file>
+        rename: <optional new name for the file>
+```
+
+### Example YAML File
+
+For an example YAML file, refer to [testdata.yml](./test/data/testdata.yml).
+
+## Development
+
+### Build
+Build the project using:
+```sh
+$ make build
+```
+
+### Test
+Run tests using:
+```sh
+$ make test
+```
+
+### Release
+Create release binaries using:
+```sh
+$ make release
+```

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module ppkgmgr
 
-go 1.20
+go 1.24
 
 require gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module ppkgmgr
 
 go 1.24
 
-require gopkg.in/yaml.v3 v3.0.1
+require gopkg.in/yaml.v3 v3.0.1 // indirect


### PR DESCRIPTION
This PR upgrades the Go toolchain and CI, bumps project metadata (version and license year), and expands project documentation with detailed usage and YAML structure.

Changes by file:
- Dockerfile
  - Upgraded Go base image from 1.20 to 1.24.
- .devcontainer/devcontainer.json
  - Removed project name for clarity.
- .github/workflows/go.yml
  - Updated actions versions and set Go version to 1.24.
- go.mod
  - Bumped Go version to 1.24; marked one dependency as indirect.
- Makefile / LICENSE
  - Bumped project version from 0.2.0 to 0.2.1 (Makefile).
  - Updated LICENSE year from 2023 to 2025.
- .vscode/settings.json
  - Added commit message generation instructions for the workspace.
- README.md
  - Added comprehensive usage examples and the YAML structure for repository definitions.
  - Included build, test, and release instructions.

Notes for reviewers:
- Run `go mod tidy` and `go test ./...`.
- Rebuild Docker/devcontainer images to confirm the updated Go base works as expected.
- Review README examples for clarity and accuracy.

This PR groups related maintenance (tooling/deps/versioning) and documentation improvements to keep the project up-to-date and easier to use.