### PR TITLE
Improve Devcontainer Setup and Error Handling

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,9 +15,8 @@ RUN apt update -y && \
     | zstd -d -o /usr/local/bin/codex && \
     chmod a+x /usr/local/bin/codex && \
 
-    apt clean && \
-    rm -rf /var/log/* ; \
-    rm -rf /tmp/*
+    go install golang.org/x/vuln/cmd/govulncheck@latest && \
+    go install honnef.co/go/tools/cmd/staticcheck@latest
 
 
 ARG CONTAINER_USERNAME=builder

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,5 @@
-###### Dockerfile
-FROM golang:1.24-bullseye
+FROM golang:1-bullseye
 
-###### Env 
 ARG USER=builder
 ARG UID=1000
 
@@ -10,30 +8,34 @@ ENV DEBIAN_FRONTEND=noninteractive \
     LANGUAGE=en_US:en \
     LC_ALL=C.UTF-8
 
-###### Run
 RUN apt update -y && \
-    apt install -y busybox gosu ; \
-    useradd -u ${UID} -s /bin/bash -m ${USER} && \
-    usermod -G root ${USER} && \
-    install --owner=${USER} --directory /work && \
-    install --owner=${USER} --directory /.cache && \
-    chmod +s /usr/sbin/gosu ; \
-    \
-    rm -rf /var/lib/apt/lists/* ; \
-    rm -rf /var/cache/apt/archives/* ; \
-    rm -rf /var/cache/apt/*.bin ; \
-    rm -rf /var/cache/debconf/*-old ; \
-    rm -rf /var/lib/dpkg/*-old ; \
+    apt install -y curl git sudo zstd make && \
+
+    curl -L https://github.com/openai/codex/releases/download/rust-v0.36.0/codex-x86_64-unknown-linux-musl.zst \
+    | zstd -d -o /usr/local/bin/codex && \
+    chmod a+x /usr/local/bin/codex && \
+
+    apt clean && \
     rm -rf /var/log/* ; \
-    rm -rf /var/tmp/* ; \
     rm -rf /tmp/*
 
-###### login user
-USER ${USER}
 
-###### working directory
+ARG CONTAINER_USERNAME=builder
+ARG CONTAINER_USERID=1000
+
+RUN useradd -u ${CONTAINER_USERID} -s /bin/bash -m ${CONTAINER_USERNAME} && \
+    install --owner=${CONTAINER_USERNAME} --directory /work && \
+    install --owner=${CONTAINER_USERNAME} --directory /.cache && \
+    echo "${CONTAINER_USERNAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/container && \
+    chmod 440 /etc/sudoers.d/container && \
+
+    apt clean && \
+    rm -rf /var/log/* ; \
+    rm -rf /tmp/*
+
+USER ${CONTAINER_USERNAME}
+
 WORKDIR /work
 
-CMD ["/bin/bash"]
 
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,16 @@
 {
+    "initializeCommand": "${localWorkspaceFolder}/.devcontainer/init.sh",
     "build": {
         "dockerfile": "Dockerfile",
         "args": {
-            "UID": "1000"
+            "CONTAINER_USERNAME": "${localEnv:USERNAME:builder}",
+            "CONTAINER_USERID": "${localEnv:USERID:1000}"
         }
     },
-    "remoteUser": "builder"
+    "mounts": [
+        "source=${localEnv:HOME}/.codex,target=/home/${localEnv:USERNAME:builder}/.codex,type=bind,consistency=cached"
+    ],
+    "workspaceMount": "source=${localWorkspaceFolder},target=/work/${localWorkspaceFolderBasename},type=bind,consistency=cached",
+    "workspaceFolder": "/work/${localWorkspaceFolderBasename}",
+    "remoteUser": "${localEnv:USERNAME:builder}"
 }

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [ -f .env ]; then
+    source .env
+fi
+
+if [ "$USERNAME" = "" ]; then
+    echo "USERNAME=$(id -u $USER -n)" >> .env
+fi
+
+if [ "$USERID" = "" ]; then
+    echo "USERID=$(id -u $USER)" >> .env
+fi
+
+if [ "$USERGROUPID" = "" ]; then
+    echo "USERGROUPID=$(id -g $USER)" >> .env
+fi
+
+

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,7 +5,9 @@ name: Go
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,6 +19,10 @@ jobs:
       with:
         go-version: '^1.24.0'
 
+    - name: Install staticcheck
+      run: |
+        go install honnef.co/go/tools/cmd/staticcheck@latest
+
     - name: Build
       run: make build
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 
 /bin
 /*.tar.gz
+/.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,243 @@
+# AGENTS.md
+
+This document is the **README for AI coding agents**. It complements the human-facing README.md so that agents can develop safely and efficiently.
+
+---
+
+## 1. Setup Steps
+
+* Recommended: VS Code Dev Container / GitHub Codespaces (use the `.devcontainer/` image).
+* Confirm you have write permission under `go env GOPATH` and that `go install` works.
+* On the first run, execute `go mod tidy` at the project root to make sure dependencies are intact.
+* Task runner: `Makefile` (CI uses the `make` targets described later).
+
+---
+
+## 2. Build & Run
+
+* Build: `go build -o ./bin/host/ ./cmd/<name>`
+* Test: `go test -v ./...`
+* Run during development: `go run ./cmd/<name>`
+* Cleanup: remove build artifacts (such as `./bin/`) with `rm -rf ./bin/` (equivalent to `make clean`).
+
+---
+
+## 3. Project Structure
+
+We follow the **Standard Go Project Layout**.
+
+```
+.
+├─ cmd/<name>/main.go     # CLI entry point
+├─ internal/              # Non-exported packages
+├─ pkg/                   # Reusable public logic
+├─ test/                  # Test fixtures
+├─ scripts/               # Installation helper scripts
+├─ bin/                   # Build artifacts (generated; not tracked by Git)
+├─ build/                 # Release artifacts
+├─ Makefile               # Build / test / release tasks
+└─ docs/                  # Documentation
+```
+
+### Roles and Guidelines
+
+* Place shared logic in `internal/` or `pkg/`. Limit `main.go` under `cmd/` to CLI bootstrapping and argument handling.
+* When adding a new CLI, create `cmd/<name>/main.go` and add a one-line description to both `README.md` and `AGENTS.md`.
+* Put `_test.go` files in the same package directory as the code under test, and use fixtures under `test/` when needed.
+* Keep public-facing logic in `pkg/` and internal-only logic in `internal/`, maintaining a one-way dependency direction.
+
+### Agent-Specific Rules
+
+* Place new files according to the directory guidelines above; avoid introducing unnecessary top-level directories.
+* When modifying existing functions, add or update unit tests and confirm `go test ./...` passes.
+* When writing files or accessing external resources, use temporary directories so existing test data is not overwritten.
+
+---
+
+## 4. Coding Standards
+
+* Always run `staticcheck ./...` so the code remains `staticcheck`-formatted.
+* Run `go vet ./...` for static checks and ensure there are no warnings (CI requirement).
+* Handle errors by returning `error`; do not silently discard them with `fmt.Println`. Prefer `fmt.Fprintf(os.Stderr, ...)` for user-facing messages.
+* Package names must be lowercase words (no snake_case). Exported identifiers use UpperCamelCase.
+* Extract magic numbers and hard-coded URLs into constants with meaningful names within the module.
+* Avoid large, unrelated refactors and keep the impact of changes minimal.
+
+---
+
+## 5. Testing & Verification
+
+* Unit tests: `go test ./...`
+* Race detection: run `go test -race ./...` when concurrency issues are suspected.
+* For additional file or network operations, use temp directories or `httptest` to avoid external dependencies.
+* When command behavior changes, keep usage examples in `README.md` and fixtures under `test` consistent.
+
+### Static Analysis / Lint / Vulnerability Scanning
+
+* Static analysis: `go vet ./...`
+* Code quality: `staticcheck ./...`
+* Vulnerability scanning: `govulncheck ./...`
+
+---
+
+## 6. CI Requirements
+
+GitHub Actions (`.github/workflows/go.yml`) runs the following:
+
+* `make build`
+* `make test`
+
+Confirm `make build` / `make test` succeed locally before opening a PR. If they fail, format and validate locally, then rerun.
+
+---
+
+## 7. Security & Data Handling
+
+* Do not commit secrets or confidential information.
+* Do not log personal or authentication data in logs or error messages.
+* Use fictitious URLs and passwords in test data; avoid hitting real services.
+* Obtain user approval before accessing external networks (disabled by default in the agent environment).
+
+---
+
+## 8. Agent Notes
+
+* If multiple `AGENTS.md` files exist, reference the one closest to your working directory (this repository only has the top-level file).
+* When instructions conflict, prioritize explicit user prompts and clarify any uncertainties.
+* Before and after your work, confirm `go build -o ./bin/host/ ./cmd/<name>` and `go test ./...` succeed. If they fail, report the cause and mitigation (the Makefile `build` / `test` targets wrap these commands).
+
+---
+
+## 9. Branch Workflow (GitHub Flow)
+
+This project follows **GitHub Flow** based on `main`.
+
+* **main branch**: Always releasable. Direct commits are forbidden; use pull requests.
+* **Feature branches (`feature/<topic>`)**: Branch from `main` for new features or enhancements, then open a PR when done.
+* **Hotfix branches (`hotfix/<issue>`)**: Branch from `main` for urgent fixes, merge promptly after CI passes.
+
+### Rules
+
+* Always branch from `main`.
+* Assign reviewers when opening a PR and merge only after CI passes.
+* Feel free to delete branches after merging.
+
+---
+
+## 10. Commit Message Policy
+
+Commit messages follow **Conventional Commits**. Agents must comply. Write the comment section in **English**.
+
+### Format
+
+```
+type(scope?): description
+```
+
+* `type`: feat / fix / docs / style / refactor / test / chore
+* `scope`: Optional; module or directory names, etc.
+* `description`: Describe the change concisely in English.
+
+### Body
+
+* Write the WHY (reason for the change) in a single English sentence.
+* List the HOW (per-file changes) in English.
+
+```
+- internal/data/data.go: Added error return when YAML parsing fails
+- pkg/req/req.go: Strengthened HTTP timeout configuration
+```
+
+### Granularity
+
+* Default to one semantic change per commit.
+* Separate generated code into logical units; do not mix with other changes.
+
+### PRs and Commits
+
+* Always document **Motivation / Design / Tests / Risks** in English in the PR description.
+* Follow team policy on squashing after reviews; if none, keep the original commit structure.
+
+---
+
+## 11. Documentation Policy
+
+* **README.md (top level)**:
+  * Introduction: tool overview, usage, installation.
+  * Later sections: developer build steps, testing instructions.
+  * Keep it accessible so first-time users can onboard smoothly.
+
+* **docs/**:
+  * Create detailed designs or supplemental docs as needed. None exist yet, so define structure and filenames when adding.
+
+* **Operational Guidelines**:
+  * Update documentation alongside code changes; if none are needed, note "No documentation changes" in the PR description.
+  * Verify sample code and command examples actually work.
+  * Include generation scripts when submitting auto-generated docs.
+
+---
+
+## 12. Dependency Management Policy
+
+* Add dependencies with `go get <module>@<version>` and keep `go.mod` / `go.sum` in sync.
+* Remove unused dependencies with `go mod tidy`.
+* For dependency updates, state the target module and reason in the PR body.
+* Check external dependencies with `govulncheck ./...` and report as needed.
+
+---
+
+## 13. Release Process
+
+* Follow **SemVer** for versioning.
+* Tag new releases with `git tag vX.Y.Z` and verify `make release` outputs.
+* Update CHANGELOG.md and reflect the changes in the release notes (include generators in the PR if they were used).
+
+### 13.1 CHANGELOG.md Policy
+
+* **Sections**: Follow `[Keep a Changelog]` categories - `Added / Changed / Fixed / Deprecated / Removed / Security`.
+* **Language**: English.
+* **Writing Principles**:
+  * Describe "what changes for the user" in one sentence; include implementation details only when needed.
+  * Emphasize **breaking changes** in bold and provide migration steps.
+  * Include PR/Issue numbers when possible (e.g., `(#123)`).
+* **Workflow**:
+  1. Add entries to the `Unreleased` section in feature PRs.
+  2. Update the version number and date in release PRs.
+  3. After tagging, copy the relevant section into the release notes.
+* **Links (recommended)**:
+  * Add comparison links at the end of the file.
+* **Supporting Tools** (optional):
+  * Use tools like `git-cliff` or `conventional-changelog` to draft entries, then edit manually.
+
+---
+
+## 14. PR Template
+
+Include the following items when creating a PR:
+
+* **Motivation**: Why this change is needed.
+* **Design**: How you implemented it.
+* **Tests**: Which tests were run.
+* **Risks**: Potential side effects or concerns.
+
+Template example:
+
+```
+### Motivation
+...
+
+### Design
+...
+
+### Tests
+...
+
+### Risks
+...
+```
+
+---
+
+## 15. Checklist
+
+*

--- a/cmd/ppkgmgr/main.go
+++ b/cmd/ppkgmgr/main.go
@@ -13,7 +13,7 @@ var (
 )
 
 func defaultData(val string, def string) string {
-	if "" == val {
+	if val == "" {
 		return def
 	}
 	return val
@@ -34,18 +34,22 @@ func main() {
 	}
 
 	if len(flag.Args()) < 1 {
-		fmt.Println("require args")
+		fmt.Fprintln(os.Stderr, "require args")
 		os.Exit(1)
 	}
 
 	path := flag.Arg(0)
 
 	if _, err := os.Stat(path); err != nil {
-		fmt.Println("not found path")
+		fmt.Fprintln(os.Stderr, "not found path")
 		os.Exit(2)
 	}
 
-	fd := data.Parse(path)
+	fd, err := data.Parse(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to parse data: %v\n", err)
+		os.Exit(3)
+	}
 
 	for _, repo := range fd.Repo {
 		for _, fs := range repo.Files {
@@ -53,7 +57,7 @@ func main() {
 			outdir := defaultData(fs.OutDir, ".")
 			outname := defaultData(fs.Rename, fs.FileName)
 			dlpath := fmt.Sprintf("%s/%s", outdir, outname)
-			if spider == true {
+			if spider {
 				fmt.Printf("%s   %s\n", dlurl, dlpath)
 			} else {
 				req.Download(dlurl, dlpath)

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module ppkgmgr
 
 go 1.24
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/data/data.go
+++ b/internal/data/data.go
@@ -1,7 +1,8 @@
 package data
 
 import (
-	"io/ioutil"
+	"fmt"
+	"os"
 
 	yaml "gopkg.in/yaml.v3"
 )
@@ -22,15 +23,17 @@ type File struct {
 	OutDir   string `yaml:"out_dir"`
 }
 
-func Parse(path string) FileData {
+func Parse(path string) (FileData, error) {
 	var fd FileData
 
-	raw, err := ioutil.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	if err != nil {
-		return fd
+		return fd, fmt.Errorf("read file: %w", err)
 	}
 
-	err = yaml.Unmarshal(raw, &fd)
+	if err := yaml.Unmarshal(raw, &fd); err != nil {
+		return fd, fmt.Errorf("decode yaml: %w", err)
+	}
 
-	return fd
+	return fd, nil
 }

--- a/internal/data/data_test.go
+++ b/internal/data/data_test.go
@@ -1,12 +1,17 @@
 package data
 
 import (
+	"errors"
+	"os"
 	"testing"
 )
 
 func TestDataParser_RepoCnt(t *testing.T) {
 
-	fd := Parse("../../test/data/testdata.yml")
+	fd, err := Parse("../../test/data/testdata.yml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	for _, repo := range fd.Repo {
 		for _, fs := range repo.Files {
@@ -23,7 +28,13 @@ func TestDataParser_RepoCnt(t *testing.T) {
 
 func TestDataParser_NotFoundFile(t *testing.T) {
 
-	fd := Parse("../../test/data/notfound_testdata.yml")
+	fd, err := Parse("../../test/data/notfound_testdata.yml")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected os.ErrNotExist, got %v", err)
+	}
 
 	if len(fd.Repo) != 0 {
 		t.Error("exp is 0")

--- a/pkg/req/req.go
+++ b/pkg/req/req.go
@@ -7,53 +7,53 @@ import (
 	"os"
 )
 
+var downloadClient = http.Client{
+	// // proxy is os environment
+	// Transport: &http.Transport{
+	// 	Proxy:                 http.ProxyURL(proxyUrl),
+	// 	ResponseHeaderTimeout: time.Duration(20) * time.Second,
+	// 	TLSHandshakeTimeout:   time.Duration(20) * time.Second,
+	// 	ExpectContinueTimeout: time.Duration(10) * time.Second,
+	// },
+	// Timeout: time.Duration(5) * time.Second,
+	CheckRedirect: func(r *http.Request, via []*http.Request) error {
+		r.URL.Opaque = r.URL.Path
+		return nil
+	},
+}
+
 func Download(url string, path string) int64 {
 
 	file, err := os.Create(path)
 
 	if err != nil {
-		fmt.Printf("Err: %s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "Err: %s\n", err.Error())
 		return 0
 	}
 
 	defer file.Close()
 
-	checkStatus := http.Client{
-		// // proxy is os environment
-		// Transport: &http.Transport{
-		// 	Proxy:                 http.ProxyURL(proxyUrl),
-		// 	ResponseHeaderTimeout: time.Duration(20) * time.Second,
-		// 	TLSHandshakeTimeout:   time.Duration(20) * time.Second,
-		// 	ExpectContinueTimeout: time.Duration(10) * time.Second,
-		// },
-		// Timeout: time.Duration(5) * time.Second,
-		CheckRedirect: func(r *http.Request, via []*http.Request) error {
-			r.URL.Opaque = r.URL.Path
-			return nil
-		},
-	}
-
-	response, err := checkStatus.Get(url)
+	response, err := downloadClient.Get(url)
 
 	if err != nil {
-		fmt.Printf("Err: %s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "Err: %s\n", err.Error())
 		return 0
 	}
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		fmt.Printf("Err: %s\n", url)
+		fmt.Fprintf(os.Stderr, "Err: %s\n", url)
 		return 0
 	}
 
 	filesize := response.ContentLength
 	dlsize, err := io.Copy(file, response.Body)
 	if (filesize != -1) && (dlsize != filesize) {
-		fmt.Printf("Truncated: %s\n", url)
+		fmt.Fprintf(os.Stderr, "Truncated: %s\n", url)
 	}
 
 	if err != nil {
-		fmt.Printf("Err: %s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "Err: %s\n", err.Error())
 		return 0
 	}
 


### PR DESCRIPTION
### Motivation
Improve the devcontainer experience and tighten runtime error handling for ppkgmgr downloads.

### Design
- Refresh the devcontainer image, add an initialization script, and mount codex assets for local users.
- Harden CLI parsing by surfacing YAML read errors and exiting with explicit status codes.
- Expand the Makefile with run, lint, and security tasks while ensuring build directories exist.
- Unify request error reporting and enable injectable HTTP clients for tests.

### Tests
Not run yet (to be covered by CI).

### Risks
The new init script writes to .env and relies on local user variables; ensure the repo root remains writable when launching the container.
