### PR TITLE
Configure Copilot to read AGENTS instructions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,13 +4,13 @@
     "diffEditor.ignoreTrimWhitespace": false,
     "github.copilot.chat.commitMessageGeneration.instructions": [
         {
-            "text": "Please write in English without exception."
-        },
-        {
-            "text": "Start the commit message by following the Conventional Commits format."
-        },
-        {
-            "text": "Then, describe the detailed changes for each file."
-        }          
+            "file": "AGENTS.md"
+        }
     ],
+    "github.copilot.chat.reviewSelection.instructions": [
+        {
+            "file": "AGENTS.md"
+        }
+    ],
+    "chat.useAgentsMdFile": true
 }


### PR DESCRIPTION
### Motivation
Ensure Copilot chat features reference the repository-specific agent instructions automatically.

### Design
- Update `.vscode/settings.json` so Copilot commit message and review prompts load instructions from `AGENTS.md`.
- Enable the shared `AGENTS.md` file usage flag for Copilot chat.

### Tests
- `go test ./...`

### Risks
- Low risk; modifies only editor configuration.

------
https://chatgpt.com/codex/tasks/task_e_68d2b359d6cc8324b290fdc67e20f41f