### PR TITLE
chore: streamline devcontainer tooling and agent configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,5 @@
 FROM golang:1-bullseye
 
-ARG USER=builder
-ARG UID=1000
-
 ENV DEBIAN_FRONTEND=noninteractive \
     LANG=C.UTF-8 \
     LANGUAGE=en_US:en \
@@ -10,13 +7,10 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 RUN apt update -y && \
     apt install -y curl git sudo zstd make && \
-
+    \
     curl -L https://github.com/openai/codex/releases/download/rust-v0.36.0/codex-x86_64-unknown-linux-musl.zst \
     | zstd -d -o /usr/local/bin/codex && \
-    chmod a+x /usr/local/bin/codex && \
-
-    go install golang.org/x/vuln/cmd/govulncheck@latest && \
-    go install honnef.co/go/tools/cmd/staticcheck@latest
+    chmod a+x /usr/local/bin/codex
 
 
 ARG CONTAINER_USERNAME=builder
@@ -27,12 +21,15 @@ RUN useradd -u ${CONTAINER_USERID} -s /bin/bash -m ${CONTAINER_USERNAME} && \
     install --owner=${CONTAINER_USERNAME} --directory /.cache && \
     echo "${CONTAINER_USERNAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/container && \
     chmod 440 /etc/sudoers.d/container && \
-
+    \
     apt clean && \
     rm -rf /var/log/* ; \
     rm -rf /tmp/*
 
 USER ${CONTAINER_USERNAME}
+
+RUN go install golang.org/x/vuln/cmd/govulncheck@latest && \
+    go install honnef.co/go/tools/cmd/staticcheck@latest
 
 WORKDIR /work
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,6 @@
 {
     "initializeCommand": "${localWorkspaceFolder}/.devcontainer/init.sh",
+    "onCreateCommand": "sudo apt-get update && sudo apt-get install -y openssh-client",
     "build": {
         "dockerfile": "Dockerfile",
         "args": {

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,3 @@
+{
+    "contextFileName": "AGENTS.md"
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/build/dockerImage/README.md
+++ b/build/dockerImage/README.md
@@ -4,9 +4,7 @@
 
 ```sh
 $ cd $project_root
-$ SUDO_USER=$(/usr/bin/logname)
 $ docker build \
-    --build-arg UID=$(id -u $SUDO_USER) \
     -t golang-work:latest .devcontainer
 ```
 


### PR DESCRIPTION
### Motivation
Keep the devcontainer tools and AI-assistant configuration aligned so that new environments match the documented agent guidance.

### Design
- .devcontainer/Dockerfile: Move Go tool installs to run as the non-root container user and drop unused build arguments.
- .devcontainer/devcontainer.json: Add an onCreateCommand that installs the SSH client required by the CLI harness.
- .gemini/settings.json: Point Gemini to AGENTS.md for shared agent guidance.
- .github/copilot-instructions.md: Symlink Copilot instructions to AGENTS.md.
- build/dockerImage/README.md: Simplify the sample Docker build command now that a sudo user argument is no longer required.

### Tests
Not run (configuration-only changes).

### Risks
Low; devcontainer rebuild should be enough to confirm SSH and Go tools remain available.
