### PR TITLE
P

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,11 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     LC_ALL=C.UTF-8
 
 RUN apt update -y && \
-    apt install -y curl git sudo zstd make && \
-    \
-    curl -L https://github.com/openai/codex/releases/download/rust-v0.36.0/codex-x86_64-unknown-linux-musl.zst \
-    | zstd -d -o /usr/local/bin/codex && \
-    chmod a+x /usr/local/bin/codex
+    apt install -y curl git sudo zstd make
 
 
 ARG CONTAINER_USERNAME=builder

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "initializeCommand": "${localWorkspaceFolder}/.devcontainer/init.sh",
-    "onCreateCommand": "sudo apt-get update && sudo apt-get install -y openssh-client",
+    "onCreateCommand": "sudo apt-get update && sudo apt-get install -y openssh-client && mkdir -p /home/${localEnv:USERNAME:builder}/bin && curl -L https://github.com/openai/codex/releases/download/rust-v0.56.0/codex-x86_64-unknown-linux-musl.zst | zstd -d -o /home/${localEnv:USERNAME:builder}/bin/codex && chmod a+x /home/${localEnv:USERNAME:builder}/bin/codex",
     "build": {
         "dockerfile": "Dockerfile",
         "args": {
@@ -13,5 +13,8 @@
     ],
     "workspaceMount": "source=${localWorkspaceFolder},target=/work/${localWorkspaceFolderBasename},type=bind,consistency=cached",
     "workspaceFolder": "/work/${localWorkspaceFolderBasename}",
-    "remoteUser": "${localEnv:USERNAME:builder}"
+    "remoteUser": "${localEnv:USERNAME:builder}",
+    "remoteEnv": {
+        "PATH": "${containerEnv:PATH}:/home/${localEnv:USERNAME:builder}/bin"
+    }
 }

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,1 +1,0 @@
-../AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@
 /bin
 /*.tar.gz
 /.env
+/.cache
+/.gocache
+/.gomodcache
+/.gopath

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,4 +240,7 @@ Template example:
 
 ## 15. Checklist
 
-*
+* [ ] `make lint`
+* [ ] `make test`
+* [ ] `make build`
+


### PR DESCRIPTION
This pull request updates the devcontainer setup to improve how the `codex` binary is installed and made available to the development environment, and makes minor documentation updates. The main changes focus on installing `codex` in the user's home directory, updating the binary version, and ensuring the user's `PATH` includes the new location. There are also minor improvements to documentation and checklists.

**Devcontainer setup improvements:**

* The installation of the `codex` binary was moved from the Dockerfile to the `onCreateCommand` in `.devcontainer/devcontainer.json`, and is now placed in `/home/${localEnv:USERNAME:builder}/bin` rather than `/usr/local/bin`. The installed version was also updated from `rust-v0.36.0` to `rust-v0.56.0`. [[1]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L9-R9) [[2]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L3-R3)
* The `PATH` environment variable is extended in `.devcontainer/devcontainer.json` to include `/home/${localEnv:USERNAME:builder}/bin`, ensuring the new binary location is available to the remote user.

**Documentation and checklist updates:**

* The reference to `../AGENTS.md` was removed from `.github/copilot-instructions.md`.
* The checklist in `AGENTS.md` was expanded to include `make lint`, `make test`, and `make build` steps.