### PR TITLE
Refine CLI download handling and add comprehensive tests

### DIFF
--- a/cmd/ppkgmgr/main.go
+++ b/cmd/ppkgmgr/main.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"ppkgmgr/internal/data"
 	"ppkgmgr/pkg/req"
@@ -64,6 +65,10 @@ func run(args []string, stdout, stderr io.Writer, downloader downloadFunc) int {
 			dlurl := fmt.Sprintf("%s/%s", repo.Url, fs.FileName)
 			outdir := defaultData(fs.OutDir, ".")
 			outname := defaultData(fs.Rename, fs.FileName)
+			if filepath.IsAbs(outname) {
+				outname = strings.TrimPrefix(outname, filepath.VolumeName(outname))
+				outname = strings.TrimLeft(outname, "/\\")
+			}
 			dlpath := filepath.Join(outdir, outname)
 			if spider {
 				fmt.Fprintf(stdout, "%s   %s\n", dlurl, dlpath)

--- a/cmd/ppkgmgr/main.go
+++ b/cmd/ppkgmgr/main.go
@@ -3,7 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
+
 	"ppkgmgr/internal/data"
 	"ppkgmgr/pkg/req"
 )
@@ -12,6 +15,8 @@ var (
 	Version = "0.0.0"
 )
 
+type downloadFunc func(string, string) (int64, error)
+
 func defaultData(val string, def string) string {
 	if val == "" {
 		return def
@@ -19,50 +24,67 @@ func defaultData(val string, def string) string {
 	return val
 }
 
-func main() {
-
+func run(args []string, stdout, stderr io.Writer, downloader downloadFunc) int {
+	fs := flag.NewFlagSet("ppkgmgr", flag.ContinueOnError)
+	fs.SetOutput(stderr)
 	var spider bool
 	var ver bool
-
-	flag.BoolVar(&spider, "spider", false, "no act")
-	flag.BoolVar(&ver, "v", false, "print version")
-	flag.Parse()
+	fs.BoolVar(&spider, "spider", false, "no act")
+	fs.BoolVar(&ver, "v", false, "print version")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
 
 	if ver {
-		fmt.Printf("Version : %s\n", Version)
-		os.Exit(0)
+		fmt.Fprintf(stdout, "Version : %s\n", Version)
+		return 0
 	}
 
-	if len(flag.Args()) < 1 {
-		fmt.Fprintln(os.Stderr, "require args")
-		os.Exit(1)
+	if len(fs.Args()) < 1 {
+		fmt.Fprintln(stderr, "require args")
+		return 1
 	}
 
-	path := flag.Arg(0)
+	path := fs.Arg(0)
 
 	if _, err := os.Stat(path); err != nil {
-		fmt.Fprintln(os.Stderr, "not found path")
-		os.Exit(2)
+		fmt.Fprintln(stderr, "not found path")
+		return 2
 	}
 
 	fd, err := data.Parse(path)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to parse data: %v\n", err)
-		os.Exit(3)
+		fmt.Fprintf(stderr, "failed to parse data: %v\n", err)
+		return 3
 	}
 
+	var downloadErr error
 	for _, repo := range fd.Repo {
 		for _, fs := range repo.Files {
 			dlurl := fmt.Sprintf("%s/%s", repo.Url, fs.FileName)
 			outdir := defaultData(fs.OutDir, ".")
 			outname := defaultData(fs.Rename, fs.FileName)
-			dlpath := fmt.Sprintf("%s/%s", outdir, outname)
+			dlpath := filepath.Join(outdir, outname)
 			if spider {
-				fmt.Printf("%s   %s\n", dlurl, dlpath)
-			} else {
-				req.Download(dlurl, dlpath)
+				fmt.Fprintf(stdout, "%s   %s\n", dlurl, dlpath)
+				continue
+			}
+
+			if _, err := downloader(dlurl, dlpath); err != nil {
+				fmt.Fprintf(stderr, "failed to download %s: %v\n", dlurl, err)
+				downloadErr = err
 			}
 		}
 	}
 
+	if downloadErr != nil {
+		return 4
+	}
+
+	return 0
+}
+
+func main() {
+	code := run(os.Args[1:], os.Stdout, os.Stderr, req.Download)
+	os.Exit(code)
 }

--- a/internal/data/data_test.go
+++ b/internal/data/data_test.go
@@ -3,31 +3,37 @@ package data
 import (
 	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
-func TestDataParser_RepoCnt(t *testing.T) {
-
+func TestParseSuccess(t *testing.T) {
 	fd, err := Parse("../../test/data/testdata.yml")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	for _, repo := range fd.Repo {
-		for _, fs := range repo.Files {
-			if fs.Rename != "" {
-				t.Error("exp is nul")
-			}
-		}
-	}
 	if len(fd.Repo) != 2 {
-		t.Error("exp is 2")
+		t.Fatalf("expected 2 repositories, got %d", len(fd.Repo))
 	}
 
+	first := fd.Repo[0]
+	if first.Comment != "jpeg" {
+		t.Fatalf("unexpected comment: %q", first.Comment)
+	}
+	if first.Url != "https://picsum.photos/200" {
+		t.Fatalf("unexpected url: %q", first.Url)
+	}
+	if len(first.Files) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(first.Files))
+	}
+	file := first.Files[0]
+	if file.FileName != "200.jpg" || file.OutDir != "./photos" || file.Rename != "" {
+		t.Fatalf("unexpected file data: %+v", file)
+	}
 }
 
-func TestDataParser_NotFoundFile(t *testing.T) {
-
+func TestParseMissingFile(t *testing.T) {
 	fd, err := Parse("../../test/data/notfound_testdata.yml")
 	if err == nil {
 		t.Fatal("expected error for missing file")
@@ -37,7 +43,19 @@ func TestDataParser_NotFoundFile(t *testing.T) {
 	}
 
 	if len(fd.Repo) != 0 {
-		t.Error("exp is 0")
+		t.Fatalf("expected 0 repositories, got %d", len(fd.Repo))
+	}
+}
+
+func TestParseInvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "invalid.yml")
+	if err := os.WriteFile(path, []byte("invalid: ["), 0o644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
 	}
 
+	_, err := Parse(path)
+	if err == nil {
+		t.Fatal("expected error for invalid yaml")
+	}
 }

--- a/pkg/req/req_test.go
+++ b/pkg/req/req_test.go
@@ -2,67 +2,124 @@ package req
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
-type roundTripFunc func(*http.Request) (*http.Response, error)
+type fakeHTTPClient struct {
+	doFunc func(*http.Request) (*http.Response, error)
+}
 
-func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
+func (f fakeHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	return f.doFunc(req)
+}
+
+func silenceStdout(tb testing.TB) func() {
+	tb.Helper()
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		tb.Fatalf("open devnull: %v", err)
+	}
+	original := os.Stdout
+	os.Stdout = devNull
+	return func() {
+		os.Stdout = original
+		devNull.Close()
+	}
+}
+
+func replaceClient(tb testing.TB, client httpClient) func() {
+	tb.Helper()
+	original := downloadClient
+	downloadClient = client
+	return func() {
+		downloadClient = original
+	}
 }
 
 func TestDownload_FileSize(t *testing.T) {
+	restoreStdout := silenceStdout(t)
+	defer restoreStdout()
 
-	tmpFile, err := os.CreateTemp("", "tmpfile")
-	if err != nil {
-		t.Fatalf("failed to create temp file: %v", err)
-	}
-	defer func() {
-		tmpFile.Close()
-		os.Remove(tmpFile.Name())
-	}()
-	orgStdout := os.Stdout
-
-	defer func() {
-		os.Stdout = orgStdout
-	}()
-	os.Stdout = nil
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "tmpfile")
 
 	filepath := "../../test/internal/req/dummyfile"
 	fixtureData, err := os.ReadFile(filepath)
 	if err != nil {
 		t.Fatalf("failed to read fixture: %v", err)
 	}
-	originalClient := downloadClient
-	downloadClient = http.Client{
-		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			return &http.Response{
-				StatusCode:    http.StatusOK,
-				Body:          io.NopCloser(bytes.NewReader(fixtureData)),
-				ContentLength: int64(len(fixtureData)),
-				Header:        make(http.Header),
-			}, nil
-		}),
-	}
-	defer func() {
-		downloadClient = originalClient
-	}()
 
-	fs, statErr := os.Stat(filepath)
-	if statErr != nil {
-		t.Fatalf("failed to stat fixture: %v", statErr)
-	}
-	Download("http://example.com/dummy", tmpFile.Name())
+	defer replaceClient(t, fakeHTTPClient{doFunc: func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			Body:          io.NopCloser(bytes.NewReader(fixtureData)),
+			ContentLength: int64(len(fixtureData)),
+			Header:        make(http.Header),
+		}, nil
+	}})()
 
-	data, err := os.ReadFile(tmpFile.Name())
+	dlsize, err := Download("http://example.com/dummy", tmpFile)
+	if err != nil {
+		t.Fatalf("Download returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(tmpFile)
 	if err != nil {
 		t.Fatalf("failed to read downloaded file: %v", err)
 	}
-	if len(data) != int(fs.Size()) {
-		t.Errorf("exp is %d != %d", len(data), fs.Size())
+	if len(data) != len(fixtureData) {
+		t.Fatalf("expected %d bytes, got %d", len(fixtureData), len(data))
 	}
+	if int64(len(fixtureData)) != dlsize {
+		t.Fatalf("expected download size %d, got %d", len(fixtureData), dlsize)
+	}
+}
 
+func TestDownload_HTTPError(t *testing.T) {
+	restoreStdout := silenceStdout(t)
+	defer restoreStdout()
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "tmpfile")
+
+	defer replaceClient(t, fakeHTTPClient{doFunc: func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Status:     "404 Not Found",
+			Body:       io.NopCloser(bytes.NewReader(nil)),
+			Header:     make(http.Header),
+		}, nil
+	}})()
+
+	if _, err := Download("http://example.com/missing", tmpFile); err == nil {
+		t.Fatal("expected error for non-200 response")
+	}
+	if _, statErr := os.Stat(tmpFile); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected file to be removed, stat error: %v", statErr)
+	}
+}
+
+func TestDownload_ClientError(t *testing.T) {
+	restoreStdout := silenceStdout(t)
+	defer restoreStdout()
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "tmpfile")
+
+	expectedErr := errors.New("network error")
+	defer replaceClient(t, fakeHTTPClient{doFunc: func(req *http.Request) (*http.Response, error) {
+		return nil, expectedErr
+	}})()
+
+	if _, err := Download("http://example.com/error", tmpFile); !errors.Is(err, expectedErr) {
+		t.Fatalf("expected %v, got %v", expectedErr, err)
+	}
+	if _, statErr := os.Stat(tmpFile); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected file to be removed, stat error: %v", statErr)
+	}
 }


### PR DESCRIPTION
### Motivation
- Harden the download pipeline with clearer error handling and cleanup.
- Improve coverage across the CLI and configuration parsing paths.

### Design
- Return detailed errors from the downloader, create output directories, and clean up failed downloads.
- Factor the CLI execution into a testable function, emit consistent messaging, and surface download failures.
- Add unit tests that exercise downloader success and failure conditions as well as CLI flag, spider, and error flows.
- Strengthen YAML parser tests to validate successful paths and malformed documents.

### Tests
- `go test ./...`

### Risks
- Low; changes touch CLI plumbing and downloader error handling but are covered by new unit tests.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691668210c808324b3055eede3b09378)