### PR TITLE
Support YAML configuration via HTTP URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 
 ### Command Examples
 ```sh
-$ ppkgmgr <path_to_yaml>  # Execute with a specified YAML file
-$ ppkgmgr --spider <path_to_yaml>  # Preview download URLs and paths
+$ ppkgmgr <path_or_url_to_yaml>  # Execute with a YAML file from disk or an HTTP(S) URL
+$ ppkgmgr --spider <path_or_url_to_yaml>  # Preview download URLs and paths
 $ ppkgmgr -v  # Display version information
 ```
 

--- a/cmd/ppkgmgr/main.go
+++ b/cmd/ppkgmgr/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -51,9 +52,11 @@ func run(args []string, stdout, stderr io.Writer, downloader downloadFunc) int {
 
 	path := fs.Arg(0)
 
-	if _, err := os.Stat(path); err != nil {
-		fmt.Fprintln(stderr, "not found path")
-		return 2
+	if !isRemotePath(path) {
+		if _, err := os.Stat(path); err != nil {
+			fmt.Fprintln(stderr, "not found path")
+			return 2
+		}
 	}
 
 	fd, err := data.Parse(path)
@@ -107,6 +110,16 @@ func run(args []string, stdout, stderr io.Writer, downloader downloadFunc) int {
 func main() {
 	code := run(os.Args[1:], os.Stdout, os.Stderr, req.Download)
 	os.Exit(code)
+}
+
+func isRemotePath(path string) bool {
+	u, err := url.Parse(path)
+	if err != nil {
+		return false
+	}
+
+	scheme := strings.ToLower(u.Scheme)
+	return scheme == "http" || scheme == "https"
 }
 
 func verifyDigest(path, expected string) (bool, string, error) {


### PR DESCRIPTION
### Motivation
- Allow the CLI to consume YAML definitions hosted remotely.

### Design
- Extend YAML parsing to load local files or fetch HTTP(S) resources with explicit error handling.
- Detect remote YAML inputs in the CLI, bypass local file checks, and cover the behaviour with unit tests.
- Refresh usage documentation to mention URLs alongside filesystem paths.

### Tests
- `go test ./...`

### Risks
- Minimal; remote fetch uses the default HTTP client without custom timeouts.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917421c43388324a84325319ee73945)