### PR TITLE
Require -f flag for manifest input

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 
 ### Command Examples
 ```sh
-$ ppkgmgr <path_or_url_to_yaml>  # Execute with a YAML file from disk or an HTTP(S) URL
-$ ppkgmgr --spider <path_or_url_to_yaml>  # Preview download URLs and paths
+$ ppkgmgr -f <path_or_url_to_yaml>  # Execute with a YAML file from disk or an HTTP(S) URL
+$ ppkgmgr --spider -f <path_or_url_to_yaml>  # Preview download URLs and paths
 $ ppkgmgr -v  # Display version information
 ```
 

--- a/cmd/ppkgmgr/main.go
+++ b/cmd/ppkgmgr/main.go
@@ -34,8 +34,10 @@ func run(args []string, stdout, stderr io.Writer, downloader downloadFunc) int {
 	fs.SetOutput(stderr)
 	var spider bool
 	var ver bool
+	var filePath string
 	fs.BoolVar(&spider, "spider", false, "no act")
 	fs.BoolVar(&ver, "v", false, "print version")
+	fs.StringVar(&filePath, "f", "", "path or URL to manifest")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -45,12 +47,17 @@ func run(args []string, stdout, stderr io.Writer, downloader downloadFunc) int {
 		return 0
 	}
 
-	if len(fs.Args()) < 1 {
-		fmt.Fprintln(stderr, "require args")
+	if filePath == "" {
+		fmt.Fprintln(stderr, "require -f option")
 		return 1
 	}
 
-	path := fs.Arg(0)
+	if len(fs.Args()) > 0 {
+		fmt.Fprintln(stderr, "unexpected arguments")
+		return 1
+	}
+
+	path := filePath
 
 	if !isRemotePath(path) {
 		if _, err := os.Stat(path); err != nil {

--- a/cmd/ppkgmgr/main_test.go
+++ b/cmd/ppkgmgr/main_test.go
@@ -39,20 +39,20 @@ func TestRun_Version(t *testing.T) {
 	}
 }
 
-func TestRun_RequireArgs(t *testing.T) {
+func TestRun_RequireFileOption(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	exitCode := run([]string{}, &stdout, &stderr, nil)
 	if exitCode != 1 {
 		t.Fatalf("expected exit code 1, got %d", exitCode)
 	}
-	if !strings.Contains(stderr.String(), "require args") {
-		t.Fatalf("expected require args message, got %q", stderr.String())
+	if !strings.Contains(stderr.String(), "require -f option") {
+		t.Fatalf("expected require -f option message, got %q", stderr.String())
 	}
 }
 
 func TestRun_PathNotFound(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	exitCode := run([]string{"missing.yml"}, &stdout, &stderr, nil)
+	exitCode := run([]string{"-f", "missing.yml"}, &stdout, &stderr, nil)
 	if exitCode != 2 {
 		t.Fatalf("expected exit code 2, got %d", exitCode)
 	}
@@ -68,7 +68,7 @@ func TestRun_ParseError(t *testing.T) {
 		t.Fatalf("failed to write bad file: %v", err)
 	}
 	var stdout, stderr bytes.Buffer
-	exitCode := run([]string{badFile}, &stdout, &stderr, nil)
+	exitCode := run([]string{"-f", badFile}, &stdout, &stderr, nil)
 	if exitCode != 3 {
 		t.Fatalf("expected exit code 3, got %d", exitCode)
 	}
@@ -85,7 +85,7 @@ func TestRun_Spider(t *testing.T) {
 		t.Fatalf("failed to write yaml: %v", err)
 	}
 	var stdout, stderr bytes.Buffer
-	exitCode := run([]string{"--spider", yamlPath}, &stdout, &stderr, nil)
+	exitCode := run([]string{"--spider", "-f", yamlPath}, &stdout, &stderr, nil)
 	if exitCode != 0 {
 		t.Fatalf("expected exit code 0, got %d", exitCode)
 	}
@@ -119,7 +119,7 @@ func TestRun_DownloadSuccess(t *testing.T) {
 		return 123, nil
 	}
 
-	exitCode := run([]string{yamlPath}, &stdout, &stderr, downloader)
+	exitCode := run([]string{"-f", yamlPath}, &stdout, &stderr, downloader)
 	if exitCode != 0 {
 		t.Fatalf("expected exit code 0, got %d", exitCode)
 	}
@@ -147,7 +147,7 @@ func TestRun_DownloadAbsoluteRename(t *testing.T) {
 		return 0, nil
 	}
 
-	exitCode := run([]string{yamlPath}, &stdout, &stderr, downloader)
+	exitCode := run([]string{"-f", yamlPath}, &stdout, &stderr, downloader)
 	if exitCode != 0 {
 		t.Fatalf("expected exit code 0, got %d", exitCode)
 	}
@@ -179,7 +179,7 @@ func TestRun_RemoteYAML(t *testing.T) {
 		return 1, nil
 	}
 
-	exitCode := run([]string{server.URL + "/config.yml"}, &stdout, &stderr, downloader)
+	exitCode := run([]string{"-f", server.URL + "/config.yml"}, &stdout, &stderr, downloader)
 	if exitCode != 0 {
 		t.Fatalf("expected exit code 0, got %d", exitCode)
 	}
@@ -205,7 +205,7 @@ func TestRun_DownloadError(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	exitCode := run([]string{yamlPath}, &stdout, &stderr, downloader)
+	exitCode := run([]string{"-f", yamlPath}, &stdout, &stderr, downloader)
 	if exitCode != 4 {
 		t.Fatalf("expected exit code 4, got %d", exitCode)
 	}
@@ -241,7 +241,7 @@ func TestRun_DownloadDigestMatch(t *testing.T) {
 		return int64(len(fileContent)), nil
 	}
 
-	exitCode := run([]string{yamlPath}, &stdout, &stderr, downloader)
+	exitCode := run([]string{"-f", yamlPath}, &stdout, &stderr, downloader)
 	if exitCode != 0 {
 		t.Fatalf("expected exit code 0, got %d", exitCode)
 	}
@@ -273,7 +273,7 @@ func TestRun_DownloadDigestMismatch(t *testing.T) {
 		return int64(len(fileContent)), nil
 	}
 
-	exitCode := run([]string{yamlPath}, &stdout, &stderr, downloader)
+	exitCode := run([]string{"-f", yamlPath}, &stdout, &stderr, downloader)
 	if exitCode != 0 {
 		t.Fatalf("expected exit code 0, got %d", exitCode)
 	}


### PR DESCRIPTION
### Motivation
- Require users to pass the manifest path via the -f flag so CLI usage matches the documented interface.

### Design
- Add required -f flag handling in the CLI and reject unexpected positional arguments.
- Update CLI tests to exercise the new flag requirement and error messaging.
- Refresh the README usage example to show the -f flag.

### Tests
- go test ./...

### Risks
- Low; scripts invoking the CLI without -f will now exit with an error.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691755d351e48324a2e8edd3299bb215)