### PR TITLE
Refactor CLI manifest maintenance

### DIFF
--- a/cmd/ppkgmgr/main.go
+++ b/cmd/ppkgmgr/main.go
@@ -1,3 +1,4 @@
+// Binary main package for the ppkgmgr command-line application.
 package main
 
 import (
@@ -7,6 +8,7 @@ import (
 	"ppkgmgr/pkg/req"
 )
 
+// Version reports the build-time version string injected by ldflags.
 var (
 	Version = "0.0.0"
 )

--- a/internal/cli/doc.go
+++ b/internal/cli/doc.go
@@ -1,0 +1,2 @@
+// Package cli implements the command-line interface for ppkgmgr.
+package cli

--- a/internal/cli/download.go
+++ b/internal/cli/download.go
@@ -2,16 +2,14 @@ package cli
 
 import (
 	"fmt"
-	"io"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"ppkgmgr/internal/data"
 
 	"github.com/spf13/cobra"
 )
 
+// newDownloadCmd wires the `dl` command that downloads manifest entries.
 func newDownloadCmd(downloader DownloadFunc) *cobra.Command {
 	var spider bool
 
@@ -51,78 +49,4 @@ func newDownloadCmd(downloader DownloadFunc) *cobra.Command {
 
 	cmd.Flags().BoolVar(&spider, "spider", false, "no dl")
 	return cmd
-}
-
-func downloadManifestFiles(fd data.FileData, downloader DownloadFunc, stdout, stderr io.Writer, spider bool) error {
-	if downloader == nil && !spider {
-		fmt.Fprintln(stderr, "downloader is required")
-		return cliError{code: 5}
-	}
-
-	var downloadErr error
-	for _, repo := range fd.Repo {
-		for _, fs := range repo.Files {
-			dlurl := fmt.Sprintf("%s/%s", repo.Url, fs.FileName)
-			dlpath, err := resolveDownloadPath(fs)
-			if err != nil {
-				fmt.Fprintf(stderr, "failed to determine download path for %s: %v\n", fs.FileName, err)
-				return cliError{code: 3}
-			}
-			if spider {
-				fmt.Fprintf(stdout, "%s   %s\n", dlurl, dlpath)
-				continue
-			}
-
-			if _, err := downloader(dlurl, dlpath); err != nil {
-				fmt.Fprintf(stderr, "failed to download %s: %v\n", dlurl, err)
-				downloadErr = err
-				continue
-			}
-
-			if fs.Digest != "" {
-				match, actual, err := verifyDigest(dlpath, fs.Digest)
-				if err != nil {
-					fmt.Fprintf(stderr, "warning: failed to verify digest for %s: %v\n", dlpath, err)
-					continue
-				}
-				if !match {
-					fmt.Fprintf(stderr, "warning: digest mismatch for %s (expected %s, got %s)\n", dlpath, fs.Digest, actual)
-				}
-			}
-		}
-	}
-
-	if downloadErr != nil {
-		return cliError{code: 4}
-	}
-	return nil
-}
-
-func resolveDownloadPath(fs data.File) (string, error) {
-	outdir := defaultData(fs.OutDir, ".")
-	expandedDir, err := expandPath(outdir)
-	if err != nil {
-		return "", fmt.Errorf("expand output directory %q: %w", outdir, err)
-	}
-	outdir = expandedDir
-	outname := defaultData(fs.Rename, fs.FileName)
-	if filepath.IsAbs(outname) {
-		outname = strings.TrimPrefix(outname, filepath.VolumeName(outname))
-		outname = strings.TrimLeft(outname, "/\\")
-	}
-	return filepath.Join(outdir, outname), nil
-}
-
-func manifestOutputPaths(fd data.FileData) ([]manifestTarget, error) {
-	var targets []manifestTarget
-	for _, repo := range fd.Repo {
-		for _, fs := range repo.Files {
-			path, err := resolveDownloadPath(fs)
-			if err != nil {
-				return nil, err
-			}
-			targets = append(targets, manifestTarget{path: path})
-		}
-	}
-	return targets, nil
 }

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/zeebo/blake3"
 )
 
+// defaultData returns def when val is empty.
 func defaultData(val string, def string) string {
 	if val == "" {
 		return def
@@ -19,6 +20,7 @@ func defaultData(val string, def string) string {
 	return val
 }
 
+// expandPath expands environment variables within path.
 func expandPath(path string) (string, error) {
 	if path == "" {
 		return "", nil
@@ -27,6 +29,7 @@ func expandPath(path string) (string, error) {
 	return os.ExpandEnv(path), nil
 }
 
+// storageDir determines the ppkgmgr working directory.
 func storageDir() (string, error) {
 	if override := os.Getenv("PPKGMGR_HOME"); override != "" {
 		return override, nil
@@ -38,6 +41,7 @@ func storageDir() (string, error) {
 	return filepath.Join(home, ".ppkgmgr"), nil
 }
 
+// isRemotePath reports whether the provided path is an HTTP(S) URL.
 func isRemotePath(path string) bool {
 	u, err := url.Parse(path)
 	if err != nil {
@@ -48,6 +52,7 @@ func isRemotePath(path string) bool {
 	return scheme == "http" || scheme == "https"
 }
 
+// verifyDigest computes a BLAKE3 digest for the file and compares it to the expected string.
 func verifyDigest(path, expected string) (bool, string, error) {
 	file, err := os.Open(path)
 	if err != nil {
@@ -71,6 +76,7 @@ func verifyDigest(path, expected string) (bool, string, error) {
 	return strings.EqualFold(expected, actualHex), actualHex, nil
 }
 
+// backupFileName generates a deterministic filename for storing manifest backups.
 func backupFileName(source string) string {
 	base := filepath.Base(source)
 	if base == "" || base == "." || base == string(filepath.Separator) {
@@ -82,6 +88,7 @@ func backupFileName(source string) string {
 	return fmt.Sprintf("%s_%s", prefix, base)
 }
 
+// sanitizeFileName converts arbitrary input into a filesystem-friendly name.
 func sanitizeFileName(name string) string {
 	var builder strings.Builder
 	for _, r := range name {
@@ -101,6 +108,7 @@ func sanitizeFileName(name string) string {
 	return result
 }
 
+// generateEntryID derives a stable identifier for a manifest source.
 func generateEntryID(source string) string {
 	sum := blake3.Sum256([]byte(source))
 	return hex.EncodeToString(sum[:8])

--- a/internal/cli/manifest.go
+++ b/internal/cli/manifest.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"ppkgmgr/internal/data"
+)
+
+// manifestTarget represents a file path generated from a manifest entry.
+type manifestTarget struct {
+	path string
+}
+
+// downloadManifestFiles walks through every file defined in the manifest and
+// downloads them using the provided downloader. When spider is true, only the
+// planned download operations are printed.
+func downloadManifestFiles(fd data.FileData, downloader DownloadFunc, stdout, stderr io.Writer, spider bool) error {
+	if downloader == nil && !spider {
+		fmt.Fprintln(stderr, "downloader is required")
+		return cliError{code: 5}
+	}
+
+	var downloadErr error
+	for _, repo := range fd.Repo {
+		for _, fs := range repo.Files {
+			dlurl := fmt.Sprintf("%s/%s", repo.Url, fs.FileName)
+			dlpath, err := resolveDownloadPath(fs)
+			if err != nil {
+				fmt.Fprintf(stderr, "failed to determine download path for %s: %v\n", fs.FileName, err)
+				return cliError{code: 3}
+			}
+			if spider {
+				fmt.Fprintf(stdout, "%s   %s\n", dlurl, dlpath)
+				continue
+			}
+
+			if _, err := downloader(dlurl, dlpath); err != nil {
+				fmt.Fprintf(stderr, "failed to download %s: %v\n", dlurl, err)
+				downloadErr = err
+				continue
+			}
+
+			if fs.Digest != "" {
+				match, actual, err := verifyDigest(dlpath, fs.Digest)
+				if err != nil {
+					fmt.Fprintf(stderr, "warning: failed to verify digest for %s: %v\n", dlpath, err)
+					continue
+				}
+				if !match {
+					fmt.Fprintf(stderr, "warning: digest mismatch for %s (expected %s, got %s)\n", dlpath, fs.Digest, actual)
+				}
+			}
+		}
+	}
+
+	if downloadErr != nil {
+		return cliError{code: 4}
+	}
+	return nil
+}
+
+// resolveDownloadPath returns the output path for a manifest entry, ensuring
+// that the resulting path is safe to use on the local filesystem.
+func resolveDownloadPath(fs data.File) (string, error) {
+	outdir := defaultData(fs.OutDir, ".")
+	expandedDir, err := expandPath(outdir)
+	if err != nil {
+		return "", fmt.Errorf("expand output directory %q: %w", outdir, err)
+	}
+	outdir = expandedDir
+	outname := defaultData(fs.Rename, fs.FileName)
+	if filepath.IsAbs(outname) {
+		outname = strings.TrimPrefix(outname, filepath.VolumeName(outname))
+		outname = strings.TrimLeft(outname, "/\\")
+	}
+	return filepath.Join(outdir, outname), nil
+}
+
+// manifestOutputPaths collects all output paths declared in the manifest.
+func manifestOutputPaths(fd data.FileData) ([]manifestTarget, error) {
+	var targets []manifestTarget
+	for _, repo := range fd.Repo {
+		for _, fs := range repo.Files {
+			path, err := resolveDownloadPath(fs)
+			if err != nil {
+				return nil, err
+			}
+			targets = append(targets, manifestTarget{path: path})
+		}
+	}
+	return targets, nil
+}

--- a/internal/cli/pkg_updater.go
+++ b/internal/cli/pkg_updater.go
@@ -1,0 +1,165 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"ppkgmgr/internal/data"
+	"ppkgmgr/internal/registry"
+)
+
+// pkgUpdater orchestrates refreshing manifests and retrieving referenced files.
+type pkgUpdater struct {
+	downloader DownloadFunc
+	stdout     io.Writer
+	stderr     io.Writer
+	force      bool
+}
+
+// run processes all registered manifests and persists any metadata updates.
+func (u *pkgUpdater) run() error {
+	if u.downloader == nil {
+		fmt.Fprintln(u.stderr, "pkg up requires a downloader")
+		return cliError{code: 5}
+	}
+
+	root, err := storageDir()
+	if err != nil {
+		fmt.Fprintf(u.stderr, "failed to determine storage directory: %v\n", err)
+		return cliError{code: 5}
+	}
+
+	registryPath := filepath.Join(root, "registry.json")
+	store, err := registry.Load(registryPath)
+	if err != nil {
+		fmt.Fprintf(u.stderr, "failed to load registry: %v\n", err)
+		return cliError{code: 5}
+	}
+
+	if len(store.Entries) == 0 {
+		fmt.Fprintln(u.stdout, "no manifests registered")
+		return nil
+	}
+
+	var hadFailure bool
+	for i := range store.Entries {
+		if u.updateEntry(&store.Entries[i]) {
+			hadFailure = true
+		}
+	}
+
+	if err := store.Save(registryPath); err != nil {
+		fmt.Fprintf(u.stderr, "failed to save registry: %v\n", err)
+		return cliError{code: 5}
+	}
+
+	if hadFailure {
+		return cliError{code: 4}
+	}
+	return nil
+}
+
+// updateEntry refreshes and downloads the files for a single manifest entry.
+func (u *pkgUpdater) updateEntry(entry *registry.Entry) bool {
+	if entry.Source == "" || entry.LocalPath == "" {
+		fmt.Fprintf(u.stderr, "warning: skipping manifest with incomplete metadata: %s\n", displayValue(entry.Source))
+		return true
+	}
+
+	var previousTargets []manifestTarget
+	if manifestTargets, err := extractManifestTargets(entry.LocalPath); err == nil {
+		previousTargets = manifestTargets
+	} else if !errors.Is(err, os.ErrNotExist) {
+		fmt.Fprintf(u.stderr, "warning: failed to parse stored manifest %s: %v\n", displayValue(entry.Source), err)
+	}
+
+	changed, err := refreshStoredManifest(entry)
+	if err != nil {
+		fmt.Fprintf(u.stderr, "warning: failed to refresh %s: %v\n", displayValue(entry.Source), err)
+		return true
+	}
+	if !changed && !u.force {
+		fmt.Fprintf(u.stdout, "manifest unchanged: %s\n", displayValue(entry.Source))
+		return false
+	}
+	if changed {
+		fmt.Fprintf(u.stdout, "refreshed manifest: %s\n", displayValue(entry.Source))
+		if len(previousTargets) != 0 {
+			cleanupOldTargets(previousTargets, u.stderr)
+		}
+	} else {
+		fmt.Fprintf(u.stdout, "forced refresh: %s\n", displayValue(entry.Source))
+	}
+
+	if _, err := os.Stat(entry.LocalPath); err != nil {
+		fmt.Fprintf(u.stderr, "warning: manifest unavailable for %s: %v\n", displayValue(entry.Source), err)
+		return true
+	}
+
+	fd, err := data.Parse(entry.LocalPath)
+	if err != nil {
+		fmt.Fprintf(u.stderr, "warning: failed to parse manifest %s: %v\n", displayValue(entry.Source), err)
+		return true
+	}
+
+	if err := downloadManifestFiles(fd, u.downloader, u.stdout, u.stderr, false); err != nil {
+		return true
+	}
+
+	fmt.Fprintf(u.stdout, "updated files for: %s\n", displayValue(entry.Source))
+	return false
+}
+
+// refreshStoredManifest downloads the source manifest and updates the registry
+// metadata with the latest digest and timestamp.
+func refreshStoredManifest(entry *registry.Entry) (bool, error) {
+	raw, err := data.LoadRaw(entry.Source)
+	if err != nil {
+		return false, err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(entry.LocalPath), 0o755); err != nil {
+		return false, err
+	}
+
+	if err := os.WriteFile(entry.LocalPath, raw, 0o600); err != nil {
+		return false, err
+	}
+
+	_, computed, err := verifyDigest(entry.LocalPath, "")
+	if err != nil {
+		return false, err
+	}
+	changed := entry.UpdatedAt.IsZero() || !strings.EqualFold(entry.Digest, computed)
+	entry.Digest = computed
+	if entry.ID == "" {
+		entry.ID = generateEntryID(entry.Source)
+	}
+	if changed {
+		entry.UpdatedAt = time.Now().UTC()
+	}
+	return changed, nil
+}
+
+// extractManifestTargets parses the manifest and collects all output paths.
+func extractManifestTargets(path string) ([]manifestTarget, error) {
+	fd, err := data.Parse(path)
+	if err != nil {
+		return nil, err
+	}
+	return manifestOutputPaths(fd)
+}
+
+// cleanupOldTargets removes any outdated files referenced by a manifest.
+func cleanupOldTargets(targets []manifestTarget, stderr io.Writer) {
+	for _, target := range targets {
+		if err := os.Remove(target.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			fmt.Fprintf(stderr, "warning: failed to remove outdated file %s: %v\n", target.path, err)
+		}
+	}
+}

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// newRepoCmd constructs the `repo` command used to manage manifest metadata.
 func newRepoCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "repo",
@@ -32,6 +33,7 @@ func newRepoCmd() *cobra.Command {
 	return cmd
 }
 
+// newRepoAddCmd registers new manifests with the local registry.
 func newRepoAddCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "add <manifest>",
@@ -46,6 +48,7 @@ func newRepoAddCmd() *cobra.Command {
 	}
 }
 
+// newRepoLsCmd lists the manifests recorded in the registry.
 func newRepoLsCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "ls",
@@ -60,6 +63,7 @@ func newRepoLsCmd() *cobra.Command {
 	}
 }
 
+// newRepoRmCmd removes manifests from the registry.
 func newRepoRmCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "rm <id_or_source>",
@@ -74,6 +78,7 @@ func newRepoRmCmd() *cobra.Command {
 	}
 }
 
+// handleRepoAdd processes the `repo add` workflow.
 func handleRepoAdd(cmd *cobra.Command, source string) error {
 	stdout := cmd.OutOrStdout()
 	stderr := cmd.ErrOrStderr()
@@ -168,6 +173,7 @@ func handleRepoAdd(cmd *cobra.Command, source string) error {
 	return nil
 }
 
+// handleRepoLs processes the `repo ls` workflow.
 func handleRepoLs(cmd *cobra.Command) error {
 	stdout := cmd.OutOrStdout()
 	stderr := cmd.ErrOrStderr()
@@ -220,6 +226,7 @@ func handleRepoLs(cmd *cobra.Command) error {
 	return nil
 }
 
+// handleRepoRm processes the `repo rm` workflow.
 func handleRepoRm(cmd *cobra.Command, selector string) error {
 	stdout := cmd.OutOrStdout()
 	stderr := cmd.ErrOrStderr()
@@ -272,6 +279,7 @@ func handleRepoRm(cmd *cobra.Command, selector string) error {
 	return nil
 }
 
+// resolveManifestSource normalises manifest references to canonical paths.
 func resolveManifestSource(source string) (string, error) {
 	if isRemotePath(source) {
 		return source, nil
@@ -293,6 +301,7 @@ func resolveManifestSource(source string) (string, error) {
 	return abs, nil
 }
 
+// displayValue returns a printable value for tabular output.
 func displayValue(val string) string {
 	if strings.TrimSpace(val) == "" {
 		return "-"
@@ -300,6 +309,7 @@ func displayValue(val string) string {
 	return val
 }
 
+// formatUpdatedAt renders a timestamp suitable for CLI output.
 func formatUpdatedAt(t time.Time) string {
 	if t.IsZero() {
 		return "-"
@@ -307,6 +317,7 @@ func formatUpdatedAt(t time.Time) string {
 	return t.UTC().Format(time.RFC3339)
 }
 
+// removeRegistryEntry removes a manifest by ID or source value.
 func removeRegistryEntry(store *registry.Store, selector string) (registry.Entry, bool) {
 	if selector == "" {
 		return registry.Entry{}, false

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// newRootCmd creates the root ppkgmgr command and attaches all subcommands.
 func newRootCmd(downloader DownloadFunc) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "ppkgmgr",

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -5,6 +5,8 @@ import (
 	"io"
 )
 
+// DownloadFunc downloads the remote file at the first argument into the
+// location provided by the second argument.
 type DownloadFunc func(string, string) (int64, error)
 
 type cliError struct {
@@ -15,6 +17,8 @@ func (e cliError) Error() string {
 	return "cli error"
 }
 
+// Run executes the ppkgmgr CLI with the provided arguments and writers,
+// returning the process exit code.
 func Run(args []string, stdout, stderr io.Writer, downloader DownloadFunc) int {
 	root := newRootCmd(downloader)
 	root.SetOut(stdout)

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -6,8 +6,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Version is set by the main package prior to executing the CLI.
 var Version = "0.0.0"
 
+// newVersionCmd reports CLI version details.
 func newVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "ver",

--- a/internal/data/data.go
+++ b/internal/data/data.go
@@ -11,16 +11,19 @@ import (
 	yaml "gopkg.in/yaml.v3"
 )
 
+// FileData represents the manifest root document.
 type FileData struct {
 	Repo []Repositories `yaml:"repositories"`
 }
 
+// Repositories describes a manifest repository entry.
 type Repositories struct {
 	Comment string `yaml:"_comment"`
 	Url     string `yaml:"url"`
 	Files   []File `yaml:"files"`
 }
 
+// File describes a downloadable file entry.
 type File struct {
 	FileName string `yaml:"file_name"`
 	Digest   string `yaml:"digest,omitempty"`
@@ -28,6 +31,7 @@ type File struct {
 	OutDir   string `yaml:"out_dir"`
 }
 
+// Parse loads and decodes the manifest at the provided path.
 func Parse(path string) (FileData, error) {
 	var fd FileData
 
@@ -43,6 +47,7 @@ func Parse(path string) (FileData, error) {
 	return fd, nil
 }
 
+// loadYAML retrieves manifest contents from the filesystem or a remote source.
 func loadYAML(path string) ([]byte, error) {
 	if isRemotePath(path) {
 		return fetchRemoteYAML(path)
@@ -55,10 +60,12 @@ func loadYAML(path string) ([]byte, error) {
 	return raw, nil
 }
 
+// LoadRaw returns the raw manifest data located at path.
 func LoadRaw(path string) ([]byte, error) {
 	return loadYAML(path)
 }
 
+// isRemotePath reports whether the manifest is hosted at an HTTP(S) URL.
 func isRemotePath(path string) bool {
 	u, err := url.Parse(path)
 	if err != nil {
@@ -69,6 +76,7 @@ func isRemotePath(path string) bool {
 	return scheme == "http" || scheme == "https"
 }
 
+// fetchRemoteYAML downloads a manifest from a remote server.
 func fetchRemoteYAML(path string) ([]byte, error) {
 	resp, err := http.Get(path)
 	if err != nil {

--- a/internal/data/doc.go
+++ b/internal/data/doc.go
@@ -1,0 +1,2 @@
+// Package data parses and loads ppkgmgr manifest files.
+package data

--- a/internal/registry/doc.go
+++ b/internal/registry/doc.go
@@ -1,0 +1,2 @@
+// Package registry persists metadata about stored manifests.
+package registry

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -10,6 +10,7 @@ import (
 	"time"
 )
 
+// Entry tracks metadata about a stored manifest.
 type Entry struct {
 	ID        string    `json:"id"`
 	Source    string    `json:"source"`
@@ -18,10 +19,12 @@ type Entry struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
+// Store contains all registry entries persisted on disk.
 type Store struct {
 	Entries []Entry `json:"entries"`
 }
 
+// Load reads registry metadata from the provided path.
 func Load(path string) (Store, error) {
 	var store Store
 
@@ -44,6 +47,7 @@ func Load(path string) (Store, error) {
 	return store, nil
 }
 
+// Save writes the registry metadata to disk in a stable order.
 func (s Store) Save(path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("create registry dir: %w", err)
@@ -66,6 +70,7 @@ func (s Store) Save(path string) error {
 	return nil
 }
 
+// Upsert inserts or replaces a registry entry by source.
 func (s *Store) Upsert(entry Entry) {
 	for i, existing := range s.Entries {
 		if existing.Source == entry.Source {
@@ -82,6 +87,7 @@ func (s *Store) Upsert(entry Entry) {
 	s.Entries = append(s.Entries, entry)
 }
 
+// GetBySource finds an entry by its source identifier.
 func (s *Store) GetBySource(source string) (Entry, bool) {
 	for _, entry := range s.Entries {
 		if entry.Source == source {
@@ -91,6 +97,7 @@ func (s *Store) GetBySource(source string) (Entry, bool) {
 	return Entry{}, false
 }
 
+// RemoveByID deletes an entry matching the ID and returns it when found.
 func (s *Store) RemoveByID(id string) (Entry, bool) {
 	for i, entry := range s.Entries {
 		if entry.ID == id {
@@ -101,6 +108,7 @@ func (s *Store) RemoveByID(id string) (Entry, bool) {
 	return Entry{}, false
 }
 
+// RemoveBySource deletes an entry matching the source and returns it when found.
 func (s *Store) RemoveBySource(source string) (Entry, bool) {
 	for i, entry := range s.Entries {
 		if entry.Source == source {

--- a/pkg/req/doc.go
+++ b/pkg/req/doc.go
@@ -1,0 +1,2 @@
+// Package req provides HTTP helpers for retrieving remote files.
+package req

--- a/pkg/req/req.go
+++ b/pkg/req/req.go
@@ -20,6 +20,7 @@ var downloadClient httpClient = &http.Client{
 	},
 }
 
+// Download retrieves the content at url and writes it to path, returning the number of bytes copied.
 func Download(url string, path string) (int64, error) {
 	if err := ensureDir(path); err != nil {
 		return 0, err
@@ -77,6 +78,7 @@ func Download(url string, path string) (int64, error) {
 	return dlsize, nil
 }
 
+// ensureDir creates the directory hierarchy required for path.
 func ensureDir(path string) error {
 	dir := filepath.Dir(path)
 	if dir == "." {
@@ -88,6 +90,7 @@ func ensureDir(path string) error {
 	return nil
 }
 
+// removeOnError best-effort deletes files created during a failed download.
 func removeOnError(path string) {
 	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
 		fmt.Fprintf(os.Stderr, "cleanup failed: %v\n", err)


### PR DESCRIPTION
### Motivation
Improve the readability and maintainability of the CLI after recent feature additions.

### Design
- Added package documentation files and descriptive comments across CLI, data, registry, and request helpers.
- Extracted manifest download utilities into a dedicated helper file and introduced a focused pkg updater workflow to trim long functions.
- Documented CLI commands and reorganized pkg command handling to route through the new updater, keeping command setup concise.

### Tests
- `go vet ./...`
- `go test ./...`

### Risks
Static analysis via `staticcheck` was not run because the tool is unavailable in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691847ea18248324875bbeb1717d696a)