### PR TITLE
Document storage dir override and add storageDir tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ $ ppkgmgr dig <path_to_file>  # Show the BLAKE3 digest for a file
 
 `pkg up` reads the stored manifests under `~/.ppkgmgr`, refreshes them from their original sources when possible, and downloads all referenced files so local copies stay up to date. When the refreshed manifest has the same digest as the stored copy, downloads are skipped to avoid unnecessary work. Pass `--redownload` when you want to bypass the digest check and download anyway; this does **not** disable the backup behavior described below.
 
+Set the `PPKGMGR_HOME` environment variable when you need to relocate the internal state directory (defaults to `~/.ppkgmgr`). This applies to commands such as `repo add`, `repo ls`, `repo rm`, and `pkg up` that read or write registry data and stored manifests.
+
 Running `ppkgmgr dl` without additional flags now preserves any pre-existing files by moving them to `<filename>.bak` (or a numbered variant) before downloading replacements. Supply `-o`/`--overwrite` when you want to skip this backup and overwrite files immediately. The same safeguard applies when `pkg up` notices a digest-protected file has been modified locally (even if `--redownload` is used) or when `repo rm` deletes tracked files—those files are renamed to `.bak` variants so user changes stay recoverable. Files without digests are always overwritten because the tool cannot determine whether a user modification occurred, so keep backups yourself when working with digestless entries.
 
 ## YAML Files

--- a/internal/cli/helpers_test.go
+++ b/internal/cli/helpers_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -26,5 +27,40 @@ func TestExpandPathEmpty(t *testing.T) {
 	}
 	if got != "" {
 		t.Fatalf("expected empty string, got %q", got)
+	}
+}
+
+func TestStorageDirOverride(t *testing.T) {
+	root := t.TempDir()
+	custom := filepath.Join(root, "state")
+	t.Setenv("PPKGMGR_HOME", custom)
+	t.Setenv("HOME", filepath.Join(root, "home"))
+
+	got, err := storageDir()
+	if err != nil {
+		t.Fatalf("storageDir returned error: %v", err)
+	}
+	if got != custom {
+		t.Fatalf("expected %q, got %q", custom, got)
+	}
+}
+
+func TestStorageDirDefaultsToHome(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatalf("failed to create fake home: %v", err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("PPKGMGR_HOME", "")
+
+	got, err := storageDir()
+	if err != nil {
+		t.Fatalf("storageDir returned error: %v", err)
+	}
+
+	want := filepath.Join(home, ".ppkgmgr")
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
 	}
 }


### PR DESCRIPTION
### Motivation
Clarify how users can relocate CLI state and ensure the behavior is covered by tests.

### Design
- Document the `PPKGMGR_HOME` environment variable for relocating registry and manifest storage.
- Add unit tests for `storageDir` defaults and override handling.

### Tests
- make lint
- make test
- make build

### Risks
- None expected; changes are limited to documentation and test coverage.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692da438711883249730ad4490c66732)