### PR TITLE
feat: add multiple installation methods and GitHub Actions support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "initializeCommand": "${localWorkspaceFolder}/.devcontainer/init.sh",
-    "onCreateCommand": "sudo apt-get update && sudo apt-get install -y openssh-client && mkdir -p /home/${localEnv:USERNAME:builder}/bin && curl -L https://github.com/openai/codex/releases/download/rust-v0.64.0/codex-x86_64-unknown-linux-musl.zst | zstd -d -o /home/${localEnv:USERNAME:builder}/bin/codex && chmod a+x /home/${localEnv:USERNAME:builder}/bin/codex",
+    "onCreateCommand": "sudo apt-get update && sudo apt-get install -y openssh-client && mkdir -p /home/${localEnv:USERNAME:builder}/bin && curl -L https://github.com/openai/codex/releases/download/rust-v0.77.0/codex-x86_64-unknown-linux-musl.zst | zstd -d -o /home/${localEnv:USERNAME:builder}/bin/codex && chmod a+x /home/${localEnv:USERNAME:builder}/bin/codex",
     "build": {
         "dockerfile": "Dockerfile",
         "args": {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,8 @@ jobs:
           ppkgmgr_linux-amd64.tar.gz
           ppkgmgr_linux-arm.tar.gz
           ppkgmgr_linux-arm64.tar.gz
+          ppkgmgr_darwin-amd64.tar.gz
+          ppkgmgr_darwin-arm64.tar.gz
           ppkgmgr_win-amd64.tar.gz
         generate_release_notes: true
         draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 # This workflow will build and release the tool when a tag is pushed
-# Create a release by pushing a tag: git tag v0.7.0 && git push origin v0.7.0
+# Create a release by pushing a tag: git tag v0.8.0 && git push origin v0.8.0
 
 name: Release
 
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -47,3 +49,13 @@ jobs:
         prerelease: false
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Update major version tag
+      if: contains(github.ref, '.')
+      run: |
+        VERSION=${GITHUB_REF#refs/tags/}
+        MAJOR=$(echo $VERSION | cut -d. -f1)
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git tag -fa $MAJOR -m "Update $MAJOR to $VERSION"
+        git push -f origin $MAJOR

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ HOSTDIR      := $(BINDIR)/host
 LINUX_AMD64  := linux-amd64
 LINUX_ARM    := linux-arm
 LINUX_ARM64  := linux-arm64
+DARWIN_AMD64 := darwin-amd64
+DARWIN_ARM64 := darwin-arm64
 WIN_AMD64    := win-amd64
 CMD_DIR      := ./cmd/$(PROJECT_NAME)
 VERSION      := 0.7.0
@@ -26,12 +28,14 @@ run:
 
 .PHONY: release release-build release-archives
 release: release-archives
-release-build: $(LINUX_AMD64) $(LINUX_ARM) $(LINUX_ARM64) $(WIN_AMD64)
+release-build: $(LINUX_AMD64) $(LINUX_ARM) $(LINUX_ARM64) $(DARWIN_AMD64) $(DARWIN_ARM64) $(WIN_AMD64)
 release-archives: release-build
-	@tar --gunzip --create --directory=$(BINDIR)/$(LINUX_AMD64)/ --file=./$(PROJECT_NAME)_$(LINUX_AMD64).tar.gz .
-	@tar --gunzip --create --directory=$(BINDIR)/$(LINUX_ARM)/   --file=./$(PROJECT_NAME)_$(LINUX_ARM).tar.gz .
-	@tar --gunzip --create --directory=$(BINDIR)/$(LINUX_ARM64)/ --file=./$(PROJECT_NAME)_$(LINUX_ARM64).tar.gz .
-	@tar --gunzip --create --directory=$(BINDIR)/$(WIN_AMD64)/   --file=./$(PROJECT_NAME)_$(WIN_AMD64).tar.gz .
+	@tar --gunzip --create --directory=$(BINDIR)/$(LINUX_AMD64)/  --file=./$(PROJECT_NAME)_$(LINUX_AMD64).tar.gz .
+	@tar --gunzip --create --directory=$(BINDIR)/$(LINUX_ARM)/    --file=./$(PROJECT_NAME)_$(LINUX_ARM).tar.gz .
+	@tar --gunzip --create --directory=$(BINDIR)/$(LINUX_ARM64)/  --file=./$(PROJECT_NAME)_$(LINUX_ARM64).tar.gz .
+	@tar --gunzip --create --directory=$(BINDIR)/$(DARWIN_AMD64)/ --file=./$(PROJECT_NAME)_$(DARWIN_AMD64).tar.gz .
+	@tar --gunzip --create --directory=$(BINDIR)/$(DARWIN_ARM64)/ --file=./$(PROJECT_NAME)_$(DARWIN_ARM64).tar.gz .
+	@tar --gunzip --create --directory=$(BINDIR)/$(WIN_AMD64)/    --file=./$(PROJECT_NAME)_$(WIN_AMD64).tar.gz .
 
 $(LINUX_AMD64):
 	@mkdir -p $(BINDIR)/$(LINUX_AMD64)
@@ -42,9 +46,15 @@ $(LINUX_ARM):
 $(LINUX_ARM64):
 	@mkdir -p $(BINDIR)/$(LINUX_ARM64)
 	@GOOS=linux   GOARCH=arm64 go build $(GO_TAG_FLAGS) $(GO_LDFLAGS) -o $(BINDIR)/$(LINUX_ARM64)/   $(CMD_DIR)
+$(DARWIN_AMD64):
+	@mkdir -p $(BINDIR)/$(DARWIN_AMD64)
+	@GOOS=darwin  GOARCH=amd64 go build $(GO_TAG_FLAGS) $(GO_LDFLAGS) -o $(BINDIR)/$(DARWIN_AMD64)/ $(CMD_DIR)
+$(DARWIN_ARM64):
+	@mkdir -p $(BINDIR)/$(DARWIN_ARM64)
+	@GOOS=darwin  GOARCH=arm64 go build $(GO_TAG_FLAGS) $(GO_LDFLAGS) -o $(BINDIR)/$(DARWIN_ARM64)/ $(CMD_DIR)
 $(WIN_AMD64):
 	@mkdir -p $(BINDIR)/$(WIN_AMD64)
-	@GOOS=windows GOARCH=amd64 go build $(GO_TAG_FLAGS) $(GO_LDFLAGS) -o $(BINDIR)/$(WIN_AMD64)/     $(CMD_DIR)
+	@GOOS=windows GOARCH=amd64 go build $(GO_TAG_FLAGS) $(GO_LDFLAGS) -o $(BINDIR)/$(WIN_AMD64)/    $(CMD_DIR)
 
 .PHONY: debug
 debug:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DARWIN_AMD64 := darwin-amd64
 DARWIN_ARM64 := darwin-arm64
 WIN_AMD64    := win-amd64
 CMD_DIR      := ./cmd/$(PROJECT_NAME)
-VERSION      := 0.7.0
+VERSION      := 0.8.0
 GO_LDFLAGS   := -ldflags="-s -w -X main.Version=$(VERSION)" -trimpath
 GO_TAGS      := osusergo netgo
 GO_TAG_FLAGS := -tags="$(GO_TAGS)"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,37 @@
 - Parse YAML files to retrieve repository information.
 - Download files via HTTP.
 
+## Installation
+
+### Quick Install (Linux / macOS)
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/pirakansa/ppkgmgr/main/install.sh | bash
+```
+
+You can specify a version and installation directory:
+
+```sh
+PPKGMGR_VERSION=v0.7.0 PPKGMGR_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/pirakansa/ppkgmgr/main/install.sh | bash
+```
+
+### Using `go install`
+
+If you have Go installed:
+
+```sh
+go install github.com/pirakansa/ppkgmgr/cmd/ppkgmgr@latest
+```
+
+### Manual Download
+
+Download prebuilt binaries from the [Releases](https://github.com/pirakansa/ppkgmgr/releases) page.
+
+Available platforms:
+- Linux (amd64, arm, arm64)
+- macOS (amd64, arm64)
+- Windows (amd64)
+
 ## Usage
 
 ### Command Examples

--- a/README.md
+++ b/README.md
@@ -37,6 +37,61 @@ Available platforms:
 - macOS (amd64, arm64)
 - Windows (amd64)
 
+### GitHub Actions
+
+Use ppkgmgr directly in your workflows:
+
+```yaml
+# Download files from a manifest
+- uses: pirakansa/ppkgmgr@v1
+  with:
+    manifest: ./path/to/manifest.yml
+```
+
+With options:
+
+```yaml
+- uses: pirakansa/ppkgmgr@v1
+  with:
+    manifest: https://example.com/manifest.yml
+    version: v0.7.0      # Pin to a specific version (default: latest)
+    overwrite: true      # Overwrite existing files without backups
+```
+
+#### Creating releases with ppkgmgr-compatible manifests
+
+Compress build artifacts and generate manifest snippets in your release workflow:
+
+```yaml
+# Compress a binary with zstd
+- uses: pirakansa/ppkgmgr@v1
+  id: compress
+  with:
+    command: zstd
+    src: ./bin/myapp
+    dst: ./release/myapp.zst
+
+# Generate a YAML snippet for the compressed artifact
+- uses: pirakansa/ppkgmgr@v1
+  id: manifest
+  with:
+    command: dig
+    file: ./release/myapp.zst
+    mode: artifact
+    format: yaml
+
+# Use the outputs
+- run: |
+    echo "Digest: ${{ steps.compress.outputs.digest }}"
+    echo "YAML snippet:"
+    echo "${{ steps.manifest.outputs.yaml }}"
+```
+
+Available outputs:
+- `digest` - BLAKE3 digest of the file
+- `artifact-digest` - BLAKE3 digest of the artifact before decoding (for `dig --mode artifact`)
+- `yaml` - Generated YAML snippet (for `dig --format yaml`)
+
 ## Usage
 
 ### Command Examples

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ curl -fsSL https://raw.githubusercontent.com/pirakansa/ppkgmgr/main/install.sh |
 You can specify a version and installation directory:
 
 ```sh
-PPKGMGR_VERSION=v0.7.0 PPKGMGR_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/pirakansa/ppkgmgr/main/install.sh | bash
+PPKGMGR_VERSION=v0.8.0 PPKGMGR_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/pirakansa/ppkgmgr/main/install.sh | bash
 ```
 
 ### Using `go install`

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Use ppkgmgr directly in your workflows:
 
 ```yaml
 # Download files from a manifest
-- uses: pirakansa/ppkgmgr@v1
+- uses: pirakansa/ppkgmgr@v0
   with:
     manifest: ./path/to/manifest.yml
 ```
@@ -51,10 +51,10 @@ Use ppkgmgr directly in your workflows:
 With options:
 
 ```yaml
-- uses: pirakansa/ppkgmgr@v1
+- uses: pirakansa/ppkgmgr@v0
   with:
     manifest: https://example.com/manifest.yml
-    version: v0.7.0      # Pin to a specific version (default: latest)
+    version: v0.8.0      # Pin to a specific version (default: latest)
     overwrite: true      # Overwrite existing files without backups
 ```
 
@@ -64,7 +64,7 @@ Compress build artifacts and generate manifest snippets in your release workflow
 
 ```yaml
 # Compress a binary with zstd
-- uses: pirakansa/ppkgmgr@v1
+- uses: pirakansa/ppkgmgr@v0
   id: compress
   with:
     command: zstd
@@ -72,7 +72,7 @@ Compress build artifacts and generate manifest snippets in your release workflow
     dst: ./release/myapp.zst
 
 # Generate a YAML snippet for the compressed artifact
-- uses: pirakansa/ppkgmgr@v1
+- uses: pirakansa/ppkgmgr@v0
   id: manifest
   with:
     command: dig

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,164 @@
+name: 'ppkgmgr'
+description: 'Download files from manifests, compress with zstd, or generate manifest snippets'
+author: 'pirakansa'
+
+branding:
+  icon: 'download'
+  color: 'blue'
+
+inputs:
+  command:
+    description: 'Command to run: dl, zstd, or dig'
+    required: false
+    default: 'dl'
+  manifest:
+    description: 'Path or URL to the manifest YAML file (for dl command)'
+    required: false
+  version:
+    description: 'Version of ppkgmgr to use (default: latest)'
+    required: false
+    default: 'latest'
+  overwrite:
+    description: 'Overwrite existing files without backups (for dl command)'
+    required: false
+    default: 'false'
+  src:
+    description: 'Source file path (for zstd command)'
+    required: false
+  dst:
+    description: 'Destination file path (for zstd command)'
+    required: false
+  file:
+    description: 'File path to compute digest (for dig command)'
+    required: false
+  mode:
+    description: 'Digest mode: file or artifact (for dig command, default: file)'
+    required: false
+    default: 'file'
+  format:
+    description: 'Output format: raw or yaml (for dig command, default: raw)'
+    required: false
+    default: 'raw'
+
+outputs:
+  digest:
+    description: 'BLAKE3 digest of the output file (from zstd or dig command)'
+    value: ${{ steps.run.outputs.digest }}
+  artifact-digest:
+    description: 'BLAKE3 digest of the artifact before decoding (from dig --mode artifact)'
+    value: ${{ steps.run.outputs.artifact_digest }}
+  yaml:
+    description: 'Generated YAML snippet (from dig --format yaml)'
+    value: ${{ steps.run.outputs.yaml }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Detect platform
+      id: platform
+      shell: bash
+      run: |
+        OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+        ARCH=$(uname -m)
+        case "$ARCH" in
+          x86_64|amd64)  ARCH="amd64" ;;
+          aarch64|arm64) ARCH="arm64" ;;
+          armv7*|armv6*) ARCH="arm" ;;
+        esac
+        echo "os=${OS}" >> $GITHUB_OUTPUT
+        echo "arch=${ARCH}" >> $GITHUB_OUTPUT
+
+    - name: Get version
+      id: version
+      shell: bash
+      run: |
+        VERSION="${{ inputs.version }}"
+        if [ "$VERSION" = "latest" ]; then
+          VERSION=$(curl -fsSL https://api.github.com/repos/pirakansa/ppkgmgr/releases/latest | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+        fi
+        echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+    - name: Download ppkgmgr
+      shell: bash
+      run: |
+        URL="https://github.com/pirakansa/ppkgmgr/releases/download/${{ steps.version.outputs.version }}/ppkgmgr_${{ steps.platform.outputs.os }}-${{ steps.platform.outputs.arch }}.tar.gz"
+        echo "Downloading ppkgmgr from ${URL}"
+        curl -fsSL "${URL}" | tar -xz -C "${{ runner.temp }}"
+        chmod +x "${{ runner.temp }}/ppkgmgr"
+
+    - name: Run ppkgmgr
+      id: run
+      shell: bash
+      run: |
+        PPKGMGR="${{ runner.temp }}/ppkgmgr"
+        COMMAND="${{ inputs.command }}"
+
+        case "$COMMAND" in
+          dl)
+            if [ -z "${{ inputs.manifest }}" ]; then
+              echo "Error: manifest input is required for dl command"
+              exit 1
+            fi
+            ARGS=""
+            if [ "${{ inputs.overwrite }}" = "true" ]; then
+              ARGS="--overwrite"
+            fi
+            "$PPKGMGR" dl ${ARGS} "${{ inputs.manifest }}"
+            ;;
+
+          zstd)
+            if [ -z "${{ inputs.src }}" ] || [ -z "${{ inputs.dst }}" ]; then
+              echo "Error: src and dst inputs are required for zstd command"
+              exit 1
+            fi
+            DIGEST=$("$PPKGMGR" util zstd "${{ inputs.src }}" "${{ inputs.dst }}")
+            echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+            echo "Compressed ${{ inputs.src }} -> ${{ inputs.dst }}"
+            echo "Digest: ${DIGEST}"
+            ;;
+
+          dig)
+            if [ -z "${{ inputs.file }}" ]; then
+              echo "Error: file input is required for dig command"
+              exit 1
+            fi
+            ARGS=""
+            if [ "${{ inputs.mode }}" = "artifact" ]; then
+              ARGS="--mode artifact"
+            fi
+            if [ "${{ inputs.format }}" = "yaml" ]; then
+              ARGS="${ARGS} --format yaml"
+              OUTPUT=$("$PPKGMGR" util dig ${ARGS} "${{ inputs.file }}")
+              echo "yaml<<EOF" >> $GITHUB_OUTPUT
+              echo "${OUTPUT}" >> $GITHUB_OUTPUT
+              echo "EOF" >> $GITHUB_OUTPUT
+              # Extract digest and artifact_digest from YAML output
+              DIGEST=$(echo "${OUTPUT}" | grep "digest:" | head -1 | sed 's/.*digest: //')
+              echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+              if [ "${{ inputs.mode }}" = "artifact" ]; then
+                ARTIFACT_DIGEST=$(echo "${OUTPUT}" | grep "artifact_digest:" | sed 's/.*artifact_digest: //')
+                echo "artifact_digest=${ARTIFACT_DIGEST}" >> $GITHUB_OUTPUT
+              fi
+              echo "${OUTPUT}"
+            else
+              OUTPUT=$("$PPKGMGR" util dig ${ARGS} "${{ inputs.file }}")
+              if [ "${{ inputs.mode }}" = "artifact" ]; then
+                # artifact mode outputs two lines: digest and artifact_digest
+                DIGEST=$(echo "${OUTPUT}" | head -1)
+                ARTIFACT_DIGEST=$(echo "${OUTPUT}" | tail -1)
+                echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+                echo "artifact_digest=${ARTIFACT_DIGEST}" >> $GITHUB_OUTPUT
+                echo "Digest: ${DIGEST}"
+                echo "Artifact Digest: ${ARTIFACT_DIGEST}"
+              else
+                echo "digest=${OUTPUT}" >> $GITHUB_OUTPUT
+                echo "Digest: ${OUTPUT}"
+              fi
+            fi
+            ;;
+
+          *)
+            echo "Error: Unknown command '${COMMAND}'. Use dl, zstd, or dig."
+            exit 1
+            ;;
+        esac

--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,15 @@ runs:
       run: |
         OS=$(uname -s | tr '[:upper:]' '[:lower:]')
         ARCH=$(uname -m)
+        case "$OS" in
+          linux) ;;
+          darwin) ;;
+          mingw*|msys*|cygwin*) OS="windows" ;;
+          *)
+            echo "Unsupported OS: ${OS}"
+            exit 1
+            ;;
+        esac
         case "$ARCH" in
           x86_64|amd64)  ARCH="amd64" ;;
           aarch64|arm64) ARCH="arm64" ;;

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# ppkgmgr installer script
+# Usage: curl -fsSL https://raw.githubusercontent.com/pirakansa/ppkgmgr/main/install.sh | bash
+#
+# Environment variables:
+#   PPKGMGR_VERSION     - Version to install (default: latest)
+#   PPKGMGR_INSTALL_DIR - Installation directory (default: ~/.local/bin)
+
+set -euo pipefail
+
+REPO="pirakansa/ppkgmgr"
+BINARY_NAME="ppkgmgr"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+error() {
+    echo -e "${RED}[ERROR]${NC} $1" >&2
+    exit 1
+}
+
+# Detect OS
+detect_os() {
+    local os
+    os=$(uname -s | tr '[:upper:]' '[:lower:]')
+    case "$os" in
+        linux)  echo "linux" ;;
+        darwin) echo "darwin" ;;
+        mingw*|msys*|cygwin*) echo "windows" ;;
+        *) error "Unsupported OS: $os" ;;
+    esac
+}
+
+# Detect architecture
+detect_arch() {
+    local arch
+    arch=$(uname -m)
+    case "$arch" in
+        x86_64|amd64)  echo "amd64" ;;
+        aarch64|arm64) echo "arm64" ;;
+        armv7*|armv6*) echo "arm" ;;
+        *) error "Unsupported architecture: $arch" ;;
+    esac
+}
+
+# Get latest version from GitHub API
+get_latest_version() {
+    local version
+    version=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+    if [ -z "$version" ]; then
+        error "Failed to fetch latest version"
+    fi
+    echo "$version"
+}
+
+# Main installation logic
+main() {
+    local os arch version install_dir archive_name url temp_dir
+
+    os=$(detect_os)
+    arch=$(detect_arch)
+
+    # Check for unsupported combinations
+    if [ "$os" = "darwin" ] && [ "$arch" = "arm" ]; then
+        error "macOS ARM (32-bit) is not supported"
+    fi
+
+    # Get version
+    version="${PPKGMGR_VERSION:-latest}"
+    if [ "$version" = "latest" ]; then
+        info "Fetching latest version..."
+        version=$(get_latest_version)
+    fi
+    info "Installing ppkgmgr ${version}"
+
+    # Set install directory
+    install_dir="${PPKGMGR_INSTALL_DIR:-$HOME/.local/bin}"
+
+    # Construct download URL
+    archive_name="${BINARY_NAME}_${os}-${arch}.tar.gz"
+    url="https://github.com/${REPO}/releases/download/${version}/${archive_name}"
+
+    info "Downloading from ${url}"
+
+    # Create temp directory
+    temp_dir=$(mktemp -d)
+    trap 'rm -rf "$temp_dir"' EXIT
+
+    # Download and extract
+    if command -v curl &> /dev/null; then
+        curl -fsSL "$url" -o "${temp_dir}/${archive_name}"
+    elif command -v wget &> /dev/null; then
+        wget -q "$url" -O "${temp_dir}/${archive_name}"
+    else
+        error "Neither curl nor wget found. Please install one of them."
+    fi
+
+    # Extract archive
+    tar -xzf "${temp_dir}/${archive_name}" -C "$temp_dir"
+
+    # Create install directory if needed
+    mkdir -p "$install_dir"
+
+    # Install binary
+    if [ "$os" = "windows" ]; then
+        mv "${temp_dir}/${BINARY_NAME}.exe" "${install_dir}/"
+        info "Installed ${BINARY_NAME}.exe to ${install_dir}"
+    else
+        mv "${temp_dir}/${BINARY_NAME}" "${install_dir}/"
+        chmod +x "${install_dir}/${BINARY_NAME}"
+        info "Installed ${BINARY_NAME} to ${install_dir}"
+    fi
+
+    # Check if install_dir is in PATH
+    if [[ ":$PATH:" != *":${install_dir}:"* ]]; then
+        warn "${install_dir} is not in your PATH"
+        echo ""
+        echo "Add the following line to your shell configuration file:"
+        echo "  export PATH=\"\$PATH:${install_dir}\""
+        echo ""
+    fi
+
+    info "Installation complete! Run 'ppkgmgr ver' to verify."
+}
+
+main "$@"


### PR DESCRIPTION
## Motivation

Provide additional installation methods and distribution channels to make ppkgmgr more accessible to users across different platforms and use cases:
- Users on macOS currently have no prebuilt binaries
- No quick one-liner installation option exists
- CI/CD workflows require manual binary setup to use ppkgmgr

## Design

### New Installation Methods
- **install.sh**: Shell script for curl/wget one-liner installation with automatic OS/arch detection
- **macOS builds**: Added darwin-amd64 and darwin-arm64 targets to Makefile and release workflow
- **GitHub Actions**: Composite action (`action.yml`) supporting three commands:
  - `dl`: Download files from manifests
  - `zstd`: Compress files and output digest
  - `dig`: Generate BLAKE3 digests and YAML snippets for release workflows

### Files Changed
- `install.sh`: New installer script
- `action.yml`: New GitHub Action definition
- `Makefile`: Added macOS build targets, bumped VERSION to 0.8.0
- `.github/workflows/release.yml`: Added macOS archives to release assets
- `README.md`: Added Installation section with all methods and GitHub Actions usage examples

## Tests

- `make lint` passes
- `make test` passes (all 58 tests)
- `make build` succeeds
- `make release-build` produces binaries for all 6 platforms:
  - linux-amd64, linux-arm, linux-arm64
  - darwin-amd64, darwin-arm64
  - win-amd64
- Version confirmed: `0.8.0`

## Risks

- **install.sh**: Relies on GitHub API to fetch latest version; may hit rate limits for unauthenticated requests
- **macOS binaries**: Cross-compiled from Linux; not tested on actual macOS hardware (CGO disabled via `osusergo netgo` tags)