### PR TITLE
fix(action): normalize OS detection and update README install version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ curl -fsSL https://raw.githubusercontent.com/pirakansa/ppkgmgr/main/install.sh |
 You can specify a version and installation directory:
 
 ```sh
-PPKGMGR_VERSION=v0.7.0 PPKGMGR_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/pirakansa/ppkgmgr/main/install.sh | bash
+PPKGMGR_VERSION=v0.8.0 PPKGMGR_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/pirakansa/ppkgmgr/main/install.sh | bash
 ```
 
 ### Using `go install`

--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,15 @@ runs:
       run: |
         OS=$(uname -s | tr '[:upper:]' '[:lower:]')
         ARCH=$(uname -m)
+        case "$OS" in
+          linux) ;;
+          darwin) ;;
+          mingw*|msys*|cygwin*) OS="windows" ;;
+          *)
+            echo "Unsupported OS: ${OS}"
+            exit 1
+            ;;
+        esac
         case "$ARCH" in
           x86_64|amd64)  ARCH="amd64" ;;
           aarch64|arm64) ARCH="arm64" ;;


### PR DESCRIPTION
### Motivation
- Windows runners produce non-release OS names (e.g., MINGW/MSYS/CYGWIN) which prevented selecting the correct release artifact.
- The README install example had drifted from the current release version.

### Description
- In `action.yml` normalize `uname -s` output by mapping `mingw*|msys*|cygwin*` to `windows` and fail fast for unsupported values.
- Preserve existing architecture normalization for `ARCH` and continue writing `os` and `arch` to `GITHUB_OUTPUT`.
- Update `README.md` install example to use `PPKGMGR_VERSION=v0.8.0`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960cd3a234883248f9ef292b256bc50)