### PR TITLE
feat: simplify onCreateCommand and update PATH for remote environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "initializeCommand": "${localWorkspaceFolder}/.devcontainer/init.sh",
-    "onCreateCommand": "sudo apt-get update && sudo apt-get install -y openssh-client && mkdir -p /home/${localEnv:USERNAME:builder}/bin && curl -L https://github.com/openai/codex/releases/download/rust-v0.77.0/codex-x86_64-unknown-linux-musl.zst | zstd -d -o /home/${localEnv:USERNAME:builder}/bin/codex && chmod a+x /home/${localEnv:USERNAME:builder}/bin/codex",
+    "onCreateCommand": "sudo apt-get update && sudo apt-get install -y openssh-client",
     "build": {
         "dockerfile": "Dockerfile",
         "args": {
@@ -8,13 +8,10 @@
             "CONTAINER_USERID": "${localEnv:USERID:1000}"
         }
     },
-    "mounts": [
-        "source=${localEnv:HOME}/.codex,target=/home/${localEnv:USERNAME:builder}/.codex,type=bind,consistency=cached"
-    ],
     "workspaceMount": "source=${localWorkspaceFolder},target=/work/${localWorkspaceFolderBasename},type=bind,consistency=cached",
     "workspaceFolder": "/work/${localWorkspaceFolderBasename}",
     "remoteUser": "${localEnv:USERNAME:builder}",
     "remoteEnv": {
-        "PATH": "${containerEnv:PATH}:/home/${localEnv:USERNAME:builder}/bin"
+        "PATH": "${containerEnv:PATH}:/home/${localEnv:USERNAME:builder}/.local/bin"
     }
 }


### PR DESCRIPTION
This pull request simplifies the devcontainer setup by removing Codex-specific installation steps and related configuration. The changes focus on streamlining the container initialization and adjusting environment paths.

Removal of Codex-specific setup:

* The `onCreateCommand` no longer downloads or installs the Codex binary; it now only installs the `openssh-client` package.
* The bind mount for `.codex` directory has been removed from the `mounts` array.
* The `PATH` environment variable now appends `.local/bin` instead of the previously used `bin` directory, reflecting the removal of Codex.