### PR TITLE
Feature/tar link support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,10 @@
-# This workflow will build and release the tool when a tag is pushed
-# Create a release by pushing a tag: git tag v0.8.0 && git push origin v0.8.0
+# This workflow builds and releases the tool on manual dispatch.
+# It reads VERSION from Makefile and creates the vX.Y.Z tag automatically.
 
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -25,6 +23,37 @@ jobs:
       with:
         go-version: '^1.24.0'
 
+    - name: Resolve version from Makefile
+      id: version
+      shell: bash
+      run: |
+        RAW_VERSION=$(sed -nE 's/^VERSION[[:space:]]*:=[[:space:]]*([0-9A-Za-z._-]+)$/\1/p' Makefile | head -n1)
+        if [ -z "$RAW_VERSION" ]; then
+          echo "failed to resolve VERSION from Makefile" >&2
+          exit 1
+        fi
+
+        TAG="v${RAW_VERSION#v}"
+        MAJOR=$(echo "$TAG" | cut -d. -f1)
+
+        echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+        echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
+        echo "Release tag: $TAG"
+
+    - name: Create and push release tag
+      shell: bash
+      run: |
+        TAG="${{ steps.version.outputs.tag }}"
+        if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+          echo "Tag already exists on origin: $TAG"
+          exit 1
+        fi
+
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git tag -a "$TAG" -m "Release $TAG"
+        git push origin "$TAG"
+
     - name: Run tests
       run: make test
 
@@ -37,6 +66,7 @@ jobs:
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
       with:
+        tag_name: ${{ steps.version.outputs.tag }}
         files: |
           ppkgmgr_linux-amd64.tar.gz
           ppkgmgr_linux-arm.tar.gz
@@ -51,11 +81,11 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Update major version tag
-      if: contains(github.ref, '.')
+      shell: bash
       run: |
-        VERSION=${GITHUB_REF#refs/tags/}
-        MAJOR=$(echo $VERSION | cut -d. -f1)
+        TAG="${{ steps.version.outputs.tag }}"
+        MAJOR="${{ steps.version.outputs.major }}"
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        git tag -fa $MAJOR -m "Update $MAJOR to $VERSION"
-        git push -f origin $MAJOR
+        git tag -fa "$MAJOR" -m "Update $MAJOR to $TAG"
+        git push -f origin "$MAJOR"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DARWIN_AMD64 := darwin-amd64
 DARWIN_ARM64 := darwin-arm64
 WIN_AMD64    := win-amd64
 CMD_DIR      := ./cmd/$(PROJECT_NAME)
-VERSION      := 0.9.0
+VERSION      := 0.9.1
 GO_LDFLAGS   := -ldflags="-s -w -X main.Version=$(VERSION)" -trimpath
 GO_TAGS      := osusergo netgo
 GO_TAG_FLAGS := -tags="$(GO_TAGS)"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ curl -fsSL https://raw.githubusercontent.com/pirakansa/ppkgmgr/main/install.sh |
 You can specify a version and installation directory:
 
 ```sh
-PPKGMGR_VERSION=v0.9.0 PPKGMGR_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/pirakansa/ppkgmgr/main/install.sh | bash
+PPKGMGR_VERSION=v0.9.1 PPKGMGR_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/pirakansa/ppkgmgr/main/install.sh | bash
 ```
 
 ### Using `go install`
@@ -50,7 +50,7 @@ With options:
 - uses: pirakansa/ppkgmgr@v0
   with:
     manifest: https://example.com/manifest.yml
-    version: v0.9.0      # Pin to a specific version (default: latest)
+    version: v0.9.1      # Pin to a specific version (default: latest)
     overwrite: true      # Overwrite existing files without backups
 ```
 

--- a/pkg/req/artifact_test.go
+++ b/pkg/req/artifact_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ulikunitz/xz"
 )
 
 func TestDecodeArtifact_RequiresOutputPathForNonArchive(t *testing.T) {
@@ -81,6 +83,61 @@ func TestDecodeArtifact_TarGzipExtractAndRename(t *testing.T) {
 	}
 }
 
+func TestDecodeArtifact_TarXzExtractAllWithSymlink(t *testing.T) {
+	archivePath := filepath.Join(t.TempDir(), "node.tar.xz")
+	archive := createTarXzForArtifactTests(t, []tarTestEntry{
+		{
+			Header: tar.Header{
+				Name: "node-v24.13.1-linux-x64/bin/node",
+				Mode: 0o755,
+				Size: int64(len("node-binary")),
+			},
+			Content: []byte("node-binary"),
+		},
+		{
+			Header: tar.Header{
+				Name:     "node-v24.13.1-linux-x64/bin/corepack",
+				Mode:     0o777,
+				Typeflag: tar.TypeSymlink,
+				Linkname: "../lib/node_modules/corepack/dist/corepack.js",
+			},
+		},
+		{
+			Header: tar.Header{
+				Name: "node-v24.13.1-linux-x64/lib/node_modules/corepack/dist/corepack.js",
+				Mode: 0o644,
+				Size: int64(len("corepack")),
+			},
+			Content: []byte("corepack"),
+		},
+	})
+	if err := os.WriteFile(archivePath, archive, 0o644); err != nil {
+		t.Fatalf("write archive: %v", err)
+	}
+
+	outDir := t.TempDir()
+	outputPath, err := DecodeArtifact(DecodeArtifactOptions{
+		Encoding:   "tar+xz",
+		SourcePath: archivePath,
+		OutputDir:  outDir,
+	})
+	if err != nil {
+		t.Fatalf("DecodeArtifact returned error: %v", err)
+	}
+	if outputPath != "" {
+		t.Fatalf("expected empty output path for full extraction, got %q", outputPath)
+	}
+
+	linkPath := filepath.Join(outDir, "node-v24.13.1-linux-x64", "bin", "corepack")
+	gotTarget, err := os.Readlink(linkPath)
+	if err != nil {
+		t.Fatalf("read symlink: %v", err)
+	}
+	if gotTarget != "../lib/node_modules/corepack/dist/corepack.js" {
+		t.Fatalf("unexpected symlink target: %q", gotTarget)
+	}
+}
+
 func createTarGzipForArtifactTests(tb testing.TB, files map[string][]byte) []byte {
 	tb.Helper()
 
@@ -107,6 +164,46 @@ func createTarGzipForArtifactTests(tb testing.TB, files map[string][]byte) []byt
 	}
 	if err := gzw.Close(); err != nil {
 		tb.Fatalf("close gzip writer: %v", err)
+	}
+
+	return compressed.Bytes()
+}
+
+type tarTestEntry struct {
+	Header  tar.Header
+	Content []byte
+}
+
+func createTarXzForArtifactTests(tb testing.TB, entries []tarTestEntry) []byte {
+	tb.Helper()
+
+	var compressed bytes.Buffer
+	xzw, err := xz.NewWriter(&compressed)
+	if err != nil {
+		tb.Fatalf("create xz writer: %v", err)
+	}
+	tw := tar.NewWriter(xzw)
+
+	for _, entry := range entries {
+		header := entry.Header
+		if header.Typeflag == 0 {
+			header.Typeflag = tar.TypeReg
+		}
+		if err := tw.WriteHeader(&header); err != nil {
+			tb.Fatalf("write tar header: %v", err)
+		}
+		if header.Typeflag == tar.TypeReg || header.Typeflag == 0 {
+			if _, err := tw.Write(entry.Content); err != nil {
+				tb.Fatalf("write tar content: %v", err)
+			}
+		}
+	}
+
+	if err := tw.Close(); err != nil {
+		tb.Fatalf("close tar writer: %v", err)
+	}
+	if err := xzw.Close(); err != nil {
+		tb.Fatalf("close xz writer: %v", err)
 	}
 
 	return compressed.Bytes()


### PR DESCRIPTION
This pull request introduces improvements to the handling of tar archive extraction, specifically adding support for symlinks and hard links, and updates documentation and versioning to reflect these changes. The most important changes are grouped below.

### Archive extraction enhancements

* Added support for extracting symlinks and hard links from tar archives in `extractTarStream`, including validation of link targets and error handling for absolute symlinks and invalid hard links. (`pkg/req/archive_tar.go`) [[1]](diffhunk://#diff-509910f2d3659017f7515a423985562a898de9eea4dc08865c0ff6b73c4775a9L78-R79) [[2]](diffhunk://#diff-509910f2d3659017f7515a423985562a898de9eea4dc08865c0ff6b73c4775a9R94-R122)
* Added `strings` import to support symlink target validation. (`pkg/req/archive_tar.go`)

### Testing improvements

* Added a new test `TestDecodeArtifact_TarXzExtractAllWithSymlink` to validate extraction of symlinks from `.tar.xz` archives, and introduced helper functions `createTarXzForArtifactTests` and `tarTestEntry` for flexible tar archive creation in tests. (`pkg/req/artifact_test.go`) [[1]](diffhunk://#diff-55e66e2067982534858ede9214b85a8ba4a620cd1d7de46ef6f19849d24ee124R86-R140) [[2]](diffhunk://#diff-55e66e2067982534858ede9214b85a8ba4a620cd1d7de46ef6f19849d24ee124R171-R210)
* Added `xz` package import for new test functionality. (`pkg/req/artifact_test.go`)

### Documentation and versioning

* Updated version references from `v0.9.0` to `v0.9.1` in `Makefile` and `README.md` to reflect the new release and ensure installation instructions are current. (`Makefile`, `README.md`) [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L13-R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R16) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-R53)