### PR TITLE
ci(release): switch release workflow to workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,7 @@ jobs:
         fi
 
         TAG="v${RAW_VERSION#v}"
-        MAJOR=$(echo "$TAG" | cut -d. -f1)
-
         echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-        echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
         echo "Release tag: $TAG"
 
     - name: Create and push release tag
@@ -79,13 +76,3 @@ jobs:
         prerelease: false
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Update major version tag
-      shell: bash
-      run: |
-        TAG="${{ steps.version.outputs.tag }}"
-        MAJOR="${{ steps.version.outputs.major }}"
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-        git tag -fa "$MAJOR" -m "Update $MAJOR to $TAG"
-        git push -f origin "$MAJOR"


### PR DESCRIPTION
Why: manual release execution should avoid local moving-tag conflicts and derive release tags from a single Makefile version source.

- .github/workflows/release.yml: replaced tag-push trigger with workflow_dispatch, resolved VERSION from Makefile, auto-created and pushed vX.Y.Z tag, and removed major moving-tag update step.